### PR TITLE
Cleanup homedir only after top suite ends

### DIFF
--- a/setup/mock-homedir.js
+++ b/setup/mock-homedir.js
@@ -11,7 +11,9 @@ if (process.env.USERPROFILE) process.env.USERPROFILE = processTmpDir;
 if (process.env.HOME) process.env.HOME = processTmpDir;
 
 deferredRunner.then(runner => {
-  runner.on('suite end', () => {
+  runner.on('suite end', suite => {
+    if (!suite.parent || !suite.parent.root) return;
+
     // Cleanup temp homedir after each top level test run
     try {
       emptyDirSync(processTmpDir);


### PR DESCRIPTION
It was cleaned after every suite (describe) ended and that produced  fails in cases where parent suite was pursuing some homedir setup