### PR TITLE
Support hooks in run-serverless util

### DIFF
--- a/docs/run-serverless.md
+++ b/docs/run-serverless.md
@@ -49,3 +49,17 @@ Registered callbacks for all other scheduled hooks will be ignored
 
 When provided, serverless instance will be created out of freshly required module,
 and provided cache map will be used as stub for underlying required modules.
+
+#### `hooks` (optional)
+
+Optional hooks, to be run in prepared mocked environemnt.
+
+Supported hooks:
+
+##### `before`
+
+Run as first step of evaluation (before `Serverless` instance is initialized, but after constructor is loaded)
+
+##### `after`
+
+Run as last step of evaluation (after `serverless.run()` resolves)

--- a/docs/run-serverless.md
+++ b/docs/run-serverless.md
@@ -40,9 +40,9 @@ Eventual environment variables (e.g. `{ SLS_DEBUG: '*' }`)
 Paths to plugins of which registered hooks should be invoked.  
 Note: All other plugins will be naturally initialized but no hooks they registered will be invoked
 
-#### `hookNamesWhiteList`
+#### `lifecycleHookNamesWhitelist`
 
-List of hooks for which callbacks should be run.
+List of lifecycle hooks for which callbacks should be run.
 Registered callbacks for all other scheduled hooks will be ignored
 
 #### `modulesCacheStup` (optional)

--- a/run-serverless.js
+++ b/run-serverless.js
@@ -39,7 +39,15 @@ const resolveServerless = (serverlessPath, modulesCacheStub, callback) => {
 
 module.exports = (
   serverlessPath,
-  { cwd, cliArgs, env, pluginPathsWhitelist, hookNamesWhitelist, modulesCacheStub, hooks = {} }
+  {
+    cwd,
+    cliArgs,
+    env,
+    pluginPathsWhitelist,
+    lifecycleHookNamesWhitelist,
+    modulesCacheStub,
+    hooks = {},
+  }
 ) =>
   overrideEnv(originalEnv => {
     process.env.APPDATA = originalEnv.APPDATA; // Needed on Windows
@@ -62,7 +70,7 @@ module.exports = (
 
               const { hooks: lifecycleHooks } = pluginManager;
               for (const hookName of Object.keys(lifecycleHooks)) {
-                if (!hookNamesWhitelist.includes(hookName)) {
+                if (!lifecycleHookNamesWhitelist.includes(hookName)) {
                   delete lifecycleHooks[hookName];
                   continue;
                 }


### PR DESCRIPTION
- Introduce `hooks` option. To enable some injections into preconfigured mocked environment
- (breaking) Rename  `hookNamesWhiteList` into `lifecycleHookNamesWhitelist`, so it's not (easily) confused with `hooks` option,