### PR TITLE
Extensive options validation for runServerless util

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -8,7 +8,7 @@ module.exports = {
     'footer-max-line-length': [2, 'always', 72],
     'header-max-length': [2, 'always', 72],
     'scope-case': [2, 'always', 'start-case'],
-    'scope-enum': [2, 'always', ['']],
+    'scope-enum': [2, 'always', ['', 'Run Serverless']],
     'subject-case': [2, 'always', 'sentence-case'],
     'subject-empty': [2, 'never'],
     'subject-full-stop': [2, 'never', '.'],

--- a/docs/run-serverless.md
+++ b/docs/run-serverless.md
@@ -11,7 +11,7 @@ const runServerless = require('@serverless/test/run-serverless');
 
 describe('Some suite', () => {
   it('Some test that involves creation of serverless instance', function() {
-    runServerless(pathToServerlessRootFolder, {
+    runServerless(serverlessPath, {
       // Options, see below documentation
     }).then(serverless => {
       // Resolved after serverless.run() finalizes.
@@ -20,6 +20,8 @@ describe('Some suite', () => {
   });
 });
 ```
+
+`serverlessPath` should point a path to Serverless Framework which we want to run test against.
 
 ### Supported options
 
@@ -38,7 +40,9 @@ Eventual environment variables (e.g. `{ SLS_DEBUG: '*' }`)
 #### `pluginPathsWhiteList`
 
 Paths to plugins of which registered hooks should be invoked.  
-Note: All other plugins will be naturally initialized but no hooks they registered will be invoked
+Note: All other plugins will be naturally initialized but no hooks they registered will be invoked.
+
+Path can be absolute or relative against `serverlessPath`.
 
 #### `lifecycleHookNamesWhitelist`
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lodash": "^4.17.15",
     "p-limit": "^2.2.1",
     "process-utils": "^2.5.0",
-    "sinon": "^7.4.2"
+    "sinon": "^7.4.2",
+    "type": "^2.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",

--- a/run-serverless.js
+++ b/run-serverless.js
@@ -77,7 +77,8 @@ module.exports = (
   });
   pluginPathsWhitelist = ensureIterable(pluginPathsWhitelist, {
     denyEmpty: true,
-    ensureItem: pluginPath => require.resolve(ensureString(pluginPath)),
+    ensureItem: pluginPath =>
+      require.resolve(path.resolve(serverlessPath, ensureString(pluginPath))),
     errorMessage:
       'Expected `pluginPathsWhitelist` to be a non empty, valid plugin paths collection,' +
       ' received %v',

--- a/run-serverless.js
+++ b/run-serverless.js
@@ -53,6 +53,17 @@ module.exports = (
     hooks = {},
   }
 ) => {
+  serverlessPath = ensureString(serverlessPath, {
+    errorMessage: "Expected 'serverlessPath' to be a string. Received: %v",
+  });
+  try {
+    require.resolve(serverlessPath);
+  } catch (error) {
+    throw new TypeError(
+      `Provided 'serverlessPath' (${serverlessPath}) ` +
+        `doesn't point a working node module: ${error.message}`
+    );
+  }
   cwd = ensureString(cwd, {
     errorMessage: '`cwd` (current working directory) is a mandatory option, received %v',
   });

--- a/run-serverless.js
+++ b/run-serverless.js
@@ -5,6 +5,7 @@ const ensureIterable = require('type/iterable/ensure');
 const ensurePlainObject = require('type/plain-object/ensure');
 const ensurePlainFunction = require('type/plain-function/ensure');
 const { entries, values } = require('lodash');
+const path = require('path');
 const overrideEnv = require('process-utils/override-env');
 const overrideCwd = require('process-utils/override-cwd');
 const overrideArgv = require('process-utils/override-argv');
@@ -53,9 +54,11 @@ module.exports = (
     hooks = {},
   }
 ) => {
-  serverlessPath = ensureString(serverlessPath, {
-    errorMessage: "Expected 'serverlessPath' to be a string. Received: %v",
-  });
+  serverlessPath = path.resolve(
+    ensureString(serverlessPath, {
+      errorMessage: "Expected 'serverlessPath' to be a string. Received: %v",
+    })
+  );
   try {
     require.resolve(serverlessPath);
   } catch (error) {
@@ -74,9 +77,10 @@ module.exports = (
   });
   pluginPathsWhitelist = ensureIterable(pluginPathsWhitelist, {
     denyEmpty: true,
-    ensureItem: ensureString,
+    ensureItem: pluginPath => require.resolve(ensureString(pluginPath)),
     errorMessage:
-      'Expected `pluginPathsWhitelist` to be a non empty string collection, received %v',
+      'Expected `pluginPathsWhitelist` to be a non empty, valid plugin paths collection,' +
+      ' received %v',
   });
   lifecycleHookNamesWhitelist = ensureIterable(lifecycleHookNamesWhitelist, {
     denyEmpty: true,

--- a/run-serverless.js
+++ b/run-serverless.js
@@ -107,15 +107,26 @@ module.exports = (
               }
 
               const { hooks: lifecycleHooks } = pluginManager;
+              const unconfirmedLifecycleHookNames = new Set(lifecycleHookNamesWhitelist);
               for (const hookName of Object.keys(lifecycleHooks)) {
                 if (!lifecycleHookNamesWhitelist.includes(hookName)) {
                   delete lifecycleHooks[hookName];
                   continue;
                 }
+
                 lifecycleHooks[hookName] = lifecycleHooks[hookName].filter(({ hook }) =>
                   whitelistedPlugins.some(whitelistedPlugin =>
                     values(whitelistedPlugin.hooks).includes(hook)
                   )
+                );
+                if (lifecycleHooks[hookName].length) unconfirmedLifecycleHookNames.delete(hookName);
+              }
+              if (unconfirmedLifecycleHookNames.size) {
+                throw new Error(
+                  'Some of whitelisted lifecycle hook names are not recognized ' +
+                    `in scope of whitelisted plugins: ${Array.from(
+                      unconfirmedLifecycleHookNames
+                    ).join(', ')}`
                 );
               }
 

--- a/run-serverless.js
+++ b/run-serverless.js
@@ -98,6 +98,13 @@ module.exports = (
               const whitelistedPlugins = pluginManager.plugins.filter(plugin =>
                 pluginConstructorsWhitelist.some(Plugin => plugin instanceof Plugin)
               );
+              for (const [index, Plugin] of pluginConstructorsWhitelist.entries()) {
+                if (!whitelistedPlugins.some(plugin => plugin instanceof Plugin)) {
+                  throw new Error(
+                    `Didn't resolve a plugin instance for ${pluginPathsWhitelist[index]}`
+                  );
+                }
+              }
 
               const { hooks: lifecycleHooks } = pluginManager;
               for (const hookName of Object.keys(lifecycleHooks)) {


### PR DESCRIPTION
Configuring `runServerless` can be challenging (especially at the beginning).

Provided validation should pick most common errors and output valuable hints that should help to understand and address discovered issues

Tested against all tests that rely on this util (in `serverless` and `@serverless/enterprise-plugin`)