### PR TITLE
Run Serverless: Support `config` option

### DIFF
--- a/docs/provision-tmp-dir.md
+++ b/docs/provision-tmp-dir.md
@@ -1,0 +1,3 @@
+# provision-tmp-dir
+
+Creates temp directory for single need and returns path to it

--- a/docs/run-serverless.md
+++ b/docs/run-serverless.md
@@ -25,9 +25,18 @@ describe('Some suite', () => {
 
 ### Supported options
 
-#### `cwd`
+#### `cwd` (interchangeable with `config` option)
 
-Working directory in which supposedly `serverless` is run
+Working directory in which supposedly `serverless` is run. Usually it's about a path to
+serverless service test fixture directory.
+
+If test can be fully accomplished just by processing serverless config, alternatively `config` option can be passed (no need then to create physical fixture directory)
+
+#### `config` (interchangeable with `cwd` option)
+
+Plain object serverless config to be used to run serverless test.
+
+It'll be written to `serverless.json` file in provisioned temporary service directory, then against that directory serverless instance will be run.
 
 #### `cliArgs` (optional)
 

--- a/provision-tmp-dir.js
+++ b/provision-tmp-dir.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const path = require('path');
+const crypto = require('crypto');
+const { mkdir } = require('fs-extra');
+const processTmpDir = require('./process-tmp-dir');
+
+module.exports = () =>
+  new Promise(resolve => {
+    const tmpDirName = path.join(processTmpDir, crypto.randomBytes(3).toString('hex'));
+    resolve(
+      mkdir(tmpDirName).then(
+        () => tmpDirName,
+        error => {
+          if (error.code !== 'EEXIST') throw error;
+          return module.exports(); // Name taken (rare edge case), retry
+        }
+      )
+    );
+  });


### PR DESCRIPTION
`config` option, as an alternative to `cwd`. Thanks to it, in simple cases (where we test purely against serverless config), there's no need to manually create a service fixture directory.

Additionally configured a `provision-tmp-dir` utility.