### PR TITLE
Extend functionality of configure-inquirer-stub

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -8,7 +8,7 @@ module.exports = {
     'footer-max-line-length': [2, 'always', 72],
     'header-max-length': [2, 'always', 72],
     'scope-case': [2, 'always', 'start-case'],
-    'scope-enum': [2, 'always', ['', 'Run Serverless']],
+    'scope-enum': [2, 'always', ['', 'Inquirer Stub', 'Run Serverless']],
     'subject-case': [2, 'always', 'sentence-case'],
     'subject-empty': [2, 'never'],
     'subject-full-stop': [2, 'never', '.'],

--- a/configure-inquirer-stub.js
+++ b/configure-inquirer-stub.js
@@ -28,8 +28,9 @@ module.exports = (inquirer, config) => {
   };
 
   if (inquirer.prompt.restore) inquirer.prompt.restore();
+  if (inquirer.createPromptModule.restore) inquirer.createPromptModule.restore();
 
-  return sinon.stub(inquirer, 'prompt').callsFake(promptConfig => {
+  sinon.stub(inquirer, 'prompt').callsFake(promptConfig => {
     if (!Array.isArray(promptConfig)) return resolveAnswer(promptConfig);
     const result = {};
     return promptConfig.reduce(
@@ -41,4 +42,8 @@ module.exports = (inquirer, config) => {
       Promise.resolve({})
     );
   });
+
+  sinon.stub(inquirer, 'createPromptModule').callsFake(() => inquirer.prompt);
+
+  return inquirer;
 };

--- a/configure-inquirer-stub.js
+++ b/configure-inquirer-stub.js
@@ -27,6 +27,8 @@ module.exports = (inquirer, config) => {
     });
   };
 
+  if (inquirer.prompt.restore) inquirer.prompt.restore();
+
   return sinon.stub(inquirer, 'prompt').callsFake(promptConfig => {
     if (!Array.isArray(promptConfig)) return resolveAnswer(promptConfig);
     const result = {};


### PR DESCRIPTION
Needed in context of https://github.com/serverless/serverless/pull/6835, where we directly run a [tabtab's inquirer prompt](https://github.com/mklabs/tabtab/blob/8e16e476331777a33b2b04fa913644c52f63b328/lib/prompt.js).

- Support multiple prompts in fake `inquirer.prompt` stub
- Ensure to mock `createPromptModule`
- Make handling of stubs easier, and automatically reset previous stub on new stub initialization