### PR TITLE
Improve env handling in runServerless

### DIFF
--- a/docs/run-serverless.md
+++ b/docs/run-serverless.md
@@ -46,6 +46,12 @@ CLI arguments (e.g. `['deploy', '--stage', 'beta']`), defaults to `[]`
 
 Eventual environment variables (e.g. `{ SLS_DEBUG: '*' }`)
 
+#### `envWhitelist` (optional)
+
+`runServerless` is run with mocked `process.env` and no env vars from original `process.env` exposed.
+
+If there's a need to expose some env vars from original env, provide this option with expected var names to expose
+
 #### `pluginPathsWhiteList`
 
 Paths to plugins of which registered hooks should be invoked.  

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "log": "^6.0.0",
     "log-node": "^7.0.0",
     "p-limit": "^2.2.1",
-    "process-utils": "^2.5.0",
+    "process-utils": "^3.0.0",
     "sinon": "^7.5.0",
     "type": "^2.0.0"
   },

--- a/resolve-env.js
+++ b/resolve-env.js
@@ -1,9 +1,9 @@
 'use strict';
 
-module.exports = () => {
-  const env = { SLS_TRACKING_DISABLED: '1' };
-  for (const varName of ['APPDATA', 'HOME', 'PATH', 'TMPDIR', 'USERPROFILE']) {
-    if (process.env[varName]) env[varName] = process.env[varName];
-  }
-  return env;
-};
+const createEnv = require('process-utils/create-env');
+
+module.exports = () =>
+  createEnv({
+    whitelist: ['APPDATA', 'HOME', 'PATH', 'TMPDIR', 'USERPROFILE'],
+    variables: { SLS_TRACKING_DISABLED: '1' },
+  });

--- a/run-serverless.js
+++ b/run-serverless.js
@@ -118,6 +118,11 @@ module.exports = (
     errorMessage:
       'Expected `hooks` to be a plain object with predefined supported hooks, received %v',
   });
+  env = ensurePlainObject(env, {
+    isOptional: true,
+    ensurePropertyValue: ensureString,
+    errorMessage: 'Expected `env` to be a plain object with string property values, received %v',
+  });
   return resolveCwd({ cwd, config }).then(confirmedCwd =>
     overrideEnv(originalEnv => {
       if (originalEnv.APPDATA) process.env.APPDATA = originalEnv.APPDATA; // Needed on Windows

--- a/run-serverless.js
+++ b/run-serverless.js
@@ -120,7 +120,7 @@ module.exports = (
   });
   return resolveCwd({ cwd, config }).then(confirmedCwd =>
     overrideEnv(originalEnv => {
-      process.env.APPDATA = originalEnv.APPDATA; // Needed on Windows
+      if (originalEnv.APPDATA) process.env.APPDATA = originalEnv.APPDATA; // Needed on Windows
       if (env) Object.assign(process.env, env);
       return overrideCwd(confirmedCwd, () =>
         overrideArgv({ args: ['serverless', ...cliArgs] }, () =>

--- a/run-serverless.js
+++ b/run-serverless.js
@@ -120,7 +120,7 @@ module.exports = (
       'Expected `hooks` to be a plain object with predefined supported hooks, received %v',
   });
   env = ensurePlainObject(env, {
-    isOptional: true,
+    default: {},
     ensurePropertyValue: ensureString,
     errorMessage: 'Expected `env` to be a plain object with string property values, received %v',
   });
@@ -135,7 +135,7 @@ module.exports = (
       for (const envVarName of envWhitelist) {
         if (originalEnv[envVarName]) process.env[envVarName] = originalEnv[envVarName];
       }
-      if (env) Object.assign(process.env, env);
+      Object.assign(process.env, env);
       return overrideCwd(confirmedCwd, () =>
         overrideArgv({ args: ['serverless', ...cliArgs] }, () =>
           resolveServerless(serverlessPath, modulesCacheStub, Serverless =>

--- a/run-serverless.js
+++ b/run-serverless.js
@@ -61,6 +61,7 @@ module.exports = (
     config,
     cliArgs,
     env,
+    envWhitelist,
     pluginPathsWhitelist,
     lifecycleHookNamesWhitelist,
     modulesCacheStub,
@@ -123,9 +124,17 @@ module.exports = (
     ensurePropertyValue: ensureString,
     errorMessage: 'Expected `env` to be a plain object with string property values, received %v',
   });
+  envWhitelist = ensureIterable(envWhitelist, {
+    default: [],
+    ensureItem: ensureString,
+    errorMessage: 'Expected `envWhitelist` to be a var names collection, received %v',
+  });
   return resolveCwd({ cwd, config }).then(confirmedCwd =>
     overrideEnv(originalEnv => {
       if (originalEnv.APPDATA) process.env.APPDATA = originalEnv.APPDATA; // Needed on Windows
+      for (const envVarName of envWhitelist) {
+        if (originalEnv[envVarName]) process.env[envVarName] = originalEnv[envVarName];
+      }
       if (env) Object.assign(process.env, env);
       return overrideCwd(confirmedCwd, () =>
         overrideArgv({ args: ['serverless', ...cliArgs] }, () =>


### PR DESCRIPTION
- Ensure not to accidentally assign `undefined` as env vars
- Validate input `env`
- Support `envVarNamesWhitelist` option