### PR TITLE
Extension to output gathered logs on test failure

### DIFF
--- a/docs/setup/log.md
+++ b/docs/setup/log.md
@@ -1,3 +1,6 @@
 # log
 
-Configure log writter to expose logs written via [log](https://github.com/medikoo/log#log) utility
+Configure log writter to expose logs written via [log](https://github.com/medikoo/log#log) utility.
+
+By default (when no logging configuration is found in enviroment) all emitted logs (down to _debug_ level) are observed
+and output in case of test failure.

--- a/docs/setup/log.md
+++ b/docs/setup/log.md
@@ -1,0 +1,3 @@
+# log
+
+Configure log writter to expose logs written via [log](https://github.com/medikoo/log#log) utility

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cli-progress-footer": "^1.1.1",
     "fs-extra": "^8.1.0",
     "lodash": "^4.17.15",
+    "log": "^6.0.0",
     "log-node": "^7.0.0",
     "p-limit": "^2.2.1",
     "process-utils": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cli-progress-footer": "^1.1.1",
     "fs-extra": "^8.1.0",
     "lodash": "^4.17.15",
+    "log-node": "^7.0.0",
     "p-limit": "^2.2.1",
     "process-utils": "^2.5.0",
     "sinon": "^7.5.0",

--- a/setup/log.js
+++ b/setup/log.js
@@ -1,0 +1,3 @@
+'use strict';
+
+require('log-node')();

--- a/setup/log.js
+++ b/setup/log.js
@@ -1,3 +1,36 @@
 'use strict';
 
-require('log-node')();
+const initializeLogWriter = require('log-node');
+
+const logWriter = initializeLogWriter();
+
+if (process.env.LOG_LEVEL || process.env.LOG_DEBUG || process.env.DEBUG) return;
+
+// Flush all gathered logs (down to DEBUG level) on test failure
+
+const logEmitter = require('log/lib/emitter');
+const { deferredRunner } = require('./mocha-reporter');
+
+const logsBuffer = [];
+const flushLogs = () => {
+  logsBuffer.forEach(event => {
+    if (!event.message) logWriter.resolveMessage(event);
+    logWriter.writeMessage(event);
+  });
+  logsBuffer.length = 0; // Empty array
+};
+
+logEmitter.on('log', event => {
+  logsBuffer.push(event);
+  if (!event.message) logWriter.resolveMessageTokens(event);
+});
+deferredRunner.then(runner => {
+  runner.on('suite end', suite => {
+    if (!suite.parent || !suite.parent.root) return;
+
+    logsBuffer.length = 0; // Empty array
+  });
+  runner.on('fail', flushLogs);
+});
+
+module.exports.flushLogs = flushLogs;


### PR DESCRIPTION
Attaches [log](https://github.com/medikoo/log-node#log-node) writer which by default flushes all observed logs (down to _debug_ level) in case of test failure.

It's about logs written with [log](https://github.com/medikoo/log#log) utility, and in case of our project [child-process-ext/spawn](https://github.com/medikoo/child-process-ext/blob/master/spawn.js) logs all std output from invoked processes.

This functionality provides reliable means to debug unexpected test failures, as then if eventual spawned processes were run via `child-process-ext/spawn`, their output will be exposed in terminal in such case.

Needed for https://github.com/serverless/serverless/pull/6867