### PR TITLE
Test log markers

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -8,7 +8,7 @@ module.exports = {
     'footer-max-line-length': [2, 'always', 72],
     'header-max-length': [2, 'always', 72],
     'scope-case': [2, 'always', 'start-case'],
-    'scope-enum': [2, 'always', ['', 'Inquirer Stub', 'Run Serverless']],
+    'scope-enum': [2, 'always', ['', 'Inquirer Stub', 'Log', 'Run Serverless']],
     'subject-case': [2, 'always', 'sentence-case'],
     'subject-empty': [2, 'never'],
     'subject-full-stop': [2, 'never', '.'],

--- a/setup/log.js
+++ b/setup/log.js
@@ -1,15 +1,21 @@
 'use strict';
 
+const log = require('log').get('mocha');
 const initializeLogWriter = require('log-node');
+const { deferredRunner } = require('./mocha-reporter');
 
 const logWriter = initializeLogWriter();
+
+deferredRunner.then(runner => {
+  runner.on('suite', suite => log.debug('suite %s', suite.title));
+  runner.on('test', suite => log.debug('test %s', suite.title));
+});
 
 if (process.env.LOG_LEVEL || process.env.LOG_DEBUG || process.env.DEBUG) return;
 
 // Flush all gathered logs (down to DEBUG level) on test failure
 
 const logEmitter = require('log/lib/emitter');
-const { deferredRunner } = require('./mocha-reporter');
 
 const logsBuffer = [];
 const flushLogs = () => {


### PR DESCRIPTION
In gathered log debug output (which is output after eventual test fail), test boundaries may not be perfectly clear.

Adding logs that indicate when given _describe_ or _it_ execution starts will solve that problem