### PR TITLE
Mocha isolated improvements

### DIFF
--- a/bin/mocha-isolated.js
+++ b/bin/mocha-isolated.js
@@ -24,7 +24,7 @@ const filePatterns = process.argv.slice(2).filter(arg => {
       inputOptions.skipFsCleanupCheck = true;
       break;
     default:
-      process.stderr.write(chalk.red.bold(`Unrecognized option ${arg}\n\n`));
+      process.stdout.write(chalk.red.bold(`Unrecognized option ${arg}\n\n`));
       process.exit(1);
   }
   return false;
@@ -56,7 +56,7 @@ const paths = mochaCollectFiles({
 }).map(filename => filename.slice(cwdPathLength));
 
 if (!paths.length) {
-  process.stderr.write(chalk.red.bold('No test files matched\n\n'));
+  process.stdout.write(chalk.red.bold('No test files matched\n\n'));
   process.exit(1);
 }
 
@@ -91,7 +91,7 @@ const run = path => {
       Promise.all([initialGitStatusDeferred, resolveGitStatus()]).then(
         ([initialStatus, currentStatus]) => {
           if (initialStatus !== currentStatus) {
-            process.stderr.write(
+            process.stdout.write(
               chalk.red.bold(`${path} didn't clean created temporary files\n\n`)
             );
             process.exit(1);
@@ -108,7 +108,7 @@ const run = path => {
   }).then(onFinally, error => {
     if (isMultiProcessRun) ongoing.clear();
     return onFinally(error).then(() => {
-      process.stderr.write(chalk.red.bold(`${path} failed\n\n`));
+      process.stdout.write(chalk.red.bold(`${path} failed\n\n`));
       if (error.code <= 2) process.exit(error.code);
       throw error;
     });

--- a/bin/mocha-isolated.js
+++ b/bin/mocha-isolated.js
@@ -35,8 +35,7 @@ const resolveGitStatus = () =>
   spawn('git', ['status', '--porcelain']).then(
     ({ stdoutBuffer }) => String(stdoutBuffer),
     error => {
-      process.stdout.write(error.stdoutBuffer);
-      process.stderr.write(error.stderrBuffer);
+      process.stdout.write(error.stdBuffer);
       throw error;
     }
   );
@@ -80,11 +79,10 @@ const run = path => {
 
   const onFinally = (() => {
     if (isMultiProcessRun) {
-      return ({ stdoutBuffer, stderrBuffer }) => {
+      return ({ stdBuffer }) => {
         ongoing.delete(path);
         cliFooter.updateProgress(Array.from(ongoing));
-        process.stdout.write(stdoutBuffer);
-        process.stderr.write(stderrBuffer);
+        process.stdout.write(stdBuffer);
         return Promise.resolve();
       };
     }

--- a/bin/mocha-isolated.js
+++ b/bin/mocha-isolated.js
@@ -17,6 +17,9 @@ const inputOptions = {};
 const filePatterns = process.argv.slice(2).filter(arg => {
   if (!arg.startsWith('-')) return true;
   switch (arg) {
+    case '--bail':
+      inputOptions.bail = true;
+      break;
     case '--pass-through-aws-creds':
       inputOptions.passThroughAwsCreds = true;
       break;
@@ -122,6 +125,7 @@ const run = path => {
       process.stdout.write(chalk.red.bold(`${path} failed\n\n`));
       if (error.code > 2) throw error;
       process.exitCode = 1;
+      if (inputOptions.bail) shouldAbort = true;
     })
   );
 };

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -8,7 +8,7 @@ module.exports = {
     'footer-max-line-length': [2, 'always', 72],
     'header-max-length': [2, 'always', 72],
     'scope-case': [2, 'always', 'start-case'],
-    'scope-enum': [2, 'always', ['', 'Inquirer Stub', 'Log', 'Run Serverless']],
+    'scope-enum': [2, 'always', ['', 'Inquirer Stub', 'Log', 'Mocha Isolated', 'Run Serverless']],
     'subject-case': [2, 'always', 'sentence-case'],
     'subject-empty': [2, 'never'],
     'subject-full-stop': [2, 'never', '.'],


### PR DESCRIPTION
- Do not hard crash on first test fail (after all test finalize write short summary on failure)
- Provide support for gentle `--bail` option, which will not propagate any further tests after first fail (and after all tests run will write a short summary on failures)
- Provide in sync dump of stdout and stderr from tests runs (seing first stdout and then stderr was not that natural)