### PR TITLE
Improvements to run-serverless util

### DIFF
--- a/docs/run-serverless.md
+++ b/docs/run-serverless.md
@@ -2,7 +2,7 @@
 
 Runs complete serverless instance in preconfigured environment, optionally with some plugins and/or lifecycle engine hooks disabled.
 
-Optionally serverless instance can be freshly required with specifc modules mocked
+Optionally serverless instance can be freshly required with specific modules mocked
 
 ## Usage
 

--- a/docs/run-serverless.md
+++ b/docs/run-serverless.md
@@ -75,12 +75,14 @@ Optional hooks, to be run in prepared mocked environemnt.
 
 Supported hooks:
 
-##### `before()`
+##### `before(Serverless, { cwd })`
 
-Run as first step of evaluation (before `Serverless` instance is initialized, but after constructor is loaded)
+Run as first step of evaluation (before `Serverless` instance is initialized, but after constructor is loaded).
+
+It's invoked with `Serverless` constructor and resolved `cwd` as meta data in arguments
 
 ##### `after(serverless)`
 
 Run as last step of evaluation (after `serverless.run()` resolves).
 
-It's invoked with `serverless` instance passed as first argument
+It's invokved with `serverless` instance passed as first argument

--- a/docs/run-serverless.md
+++ b/docs/run-serverless.md
@@ -75,10 +75,12 @@ Optional hooks, to be run in prepared mocked environemnt.
 
 Supported hooks:
 
-##### `before`
+##### `before()`
 
 Run as first step of evaluation (before `Serverless` instance is initialized, but after constructor is loaded)
 
-##### `after`
+##### `after(serverless)`
 
-Run as last step of evaluation (after `serverless.run()` resolves)
+Run as last step of evaluation (after `serverless.run()` resolves).
+
+It's invoked with `serverless` instance passed as first argument

--- a/docs/run-serverless.md
+++ b/docs/run-serverless.md
@@ -1,6 +1,6 @@
 # run-serverless
 
-Runs complete serverless instance in preconfigured environment, limited to predefined plugins and hook events.
+Runs complete serverless instance in preconfigured environment, optionally with some plugins and/or lifecycle engine hooks disabled.
 
 Optionally serverless instance can be freshly required with specifc modules mocked
 
@@ -52,17 +52,15 @@ Eventual environment variables (e.g. `{ SLS_DEBUG: '*' }`)
 
 If there's a need to expose some env vars from original env, provide this option with expected var names to expose
 
-#### `pluginPathsWhiteList`
+#### `pluginPathsBlacklist`
 
-Paths to plugins of which registered hooks should be invoked.  
-Note: All other plugins will be naturally initialized but no hooks they registered will be invoked.
+Paths to plugins of which registered hooks should not be invoked (note plugin will remain initialized)
 
 Path can be absolute or relative against `serverlessPath`.
 
-#### `lifecycleHookNamesWhitelist`
+#### `lifecycleHookNamesBlacklist`
 
-List of lifecycle hooks for which callbacks should be run.
-Registered callbacks for all other scheduled hooks will be ignored
+List of lifecycle hooks for which callbacks should not be run.
 
 #### `modulesCacheStup` (optional)
 

--- a/run-serverless.js
+++ b/run-serverless.js
@@ -135,82 +135,84 @@ module.exports = (
       return overrideCwd(confirmedCwd, () =>
         overrideArgv({ args: ['serverless', ...cliArgs] }, () =>
           resolveServerless(serverlessPath, modulesCacheStub, Serverless =>
-            Promise.resolve(hooks.before && hooks.before()).then(() => {
-              // Intialize serverless instances in preconfigured environment
-              const serverless = new Serverless();
-              const { pluginManager } = serverless;
-              const pluginConstructorsWhitelist = pluginPathsWhitelist.map(pluginPath =>
-                require(pluginPath)
-              );
-              return serverless.init().then(() => {
-                // Strip registered hooks, so only those intended are executed
-                const whitelistedPlugins = pluginManager.plugins.filter(plugin =>
-                  pluginConstructorsWhitelist.some(Plugin => plugin instanceof Plugin)
+            Promise.resolve(hooks.before && hooks.before(Serverless, { cwd: confirmedCwd })).then(
+              () => {
+                // Intialize serverless instances in preconfigured environment
+                const serverless = new Serverless();
+                const { pluginManager } = serverless;
+                const pluginConstructorsWhitelist = pluginPathsWhitelist.map(pluginPath =>
+                  require(pluginPath)
                 );
-                for (const [index, Plugin] of pluginConstructorsWhitelist.entries()) {
-                  if (!whitelistedPlugins.some(plugin => plugin instanceof Plugin)) {
-                    throw new Error(
-                      `Didn't resolve a plugin instance for ${pluginPathsWhitelist[index]}`
-                    );
-                  }
-                }
-
-                const { hooks: lifecycleHooks } = pluginManager;
-                const unconfirmedLifecycleHookNames = new Set(lifecycleHookNamesWhitelist);
-                const notExecutedLifecycleHookNames = new Set(lifecycleHookNamesWhitelist);
-                for (const hookName of Object.keys(lifecycleHooks)) {
-                  if (!lifecycleHookNamesWhitelist.includes(hookName)) {
-                    delete lifecycleHooks[hookName];
-                    continue;
-                  }
-
-                  lifecycleHooks[hookName] = lifecycleHooks[hookName].filter(hookData => {
-                    if (
-                      !whitelistedPlugins.some(whitelistedPlugin =>
-                        values(whitelistedPlugin.hooks).includes(hookData.hook)
-                      )
-                    ) {
-                      return false;
-                    }
-                    const originalHook = hookData.hook;
-                    hookData.hook = function(...args) {
-                      notExecutedLifecycleHookNames.delete(hookName);
-                      return originalHook.apply(this, args);
-                    };
-                    return true;
-                  });
-
-                  if (lifecycleHooks[hookName].length) {
-                    unconfirmedLifecycleHookNames.delete(hookName);
-                  }
-                }
-                if (unconfirmedLifecycleHookNames.size) {
-                  throw new Error(
-                    `${Array.from(unconfirmedLifecycleHookNames).join(
-                      ', '
-                    )} whitelisted lifecycle hook names were not recognized ` +
-                      'in scope of whitelisted plugins'
+                return serverless.init().then(() => {
+                  // Strip registered hooks, so only those intended are executed
+                  const whitelistedPlugins = pluginManager.plugins.filter(plugin =>
+                    pluginConstructorsWhitelist.some(Plugin => plugin instanceof Plugin)
                   );
-                }
-
-                // Run plugin manager hooks
-                return serverless
-                  .run()
-                  .then(() => {
-                    if (notExecutedLifecycleHookNames.size) {
+                  for (const [index, Plugin] of pluginConstructorsWhitelist.entries()) {
+                    if (!whitelistedPlugins.some(plugin => plugin instanceof Plugin)) {
                       throw new Error(
-                        `${Array.from(unconfirmedLifecycleHookNames).join(
-                          ', '
-                        )} whitelisted lifecycle hooks were not executed. ` +
-                          'Ensure to enforce desired serverless command via `cliArgs` option.'
+                        `Didn't resolve a plugin instance for ${pluginPathsWhitelist[index]}`
                       );
                     }
-                    if (hooks.after) return hooks.after(serverless);
-                    return null;
-                  })
-                  .then(() => serverless);
-              });
-            })
+                  }
+
+                  const { hooks: lifecycleHooks } = pluginManager;
+                  const unconfirmedLifecycleHookNames = new Set(lifecycleHookNamesWhitelist);
+                  const notExecutedLifecycleHookNames = new Set(lifecycleHookNamesWhitelist);
+                  for (const hookName of Object.keys(lifecycleHooks)) {
+                    if (!lifecycleHookNamesWhitelist.includes(hookName)) {
+                      delete lifecycleHooks[hookName];
+                      continue;
+                    }
+
+                    lifecycleHooks[hookName] = lifecycleHooks[hookName].filter(hookData => {
+                      if (
+                        !whitelistedPlugins.some(whitelistedPlugin =>
+                          values(whitelistedPlugin.hooks).includes(hookData.hook)
+                        )
+                      ) {
+                        return false;
+                      }
+                      const originalHook = hookData.hook;
+                      hookData.hook = function(...args) {
+                        notExecutedLifecycleHookNames.delete(hookName);
+                        return originalHook.apply(this, args);
+                      };
+                      return true;
+                    });
+
+                    if (lifecycleHooks[hookName].length) {
+                      unconfirmedLifecycleHookNames.delete(hookName);
+                    }
+                  }
+                  if (unconfirmedLifecycleHookNames.size) {
+                    throw new Error(
+                      `${Array.from(unconfirmedLifecycleHookNames).join(
+                        ', '
+                      )} whitelisted lifecycle hook names were not recognized ` +
+                        'in scope of whitelisted plugins'
+                    );
+                  }
+
+                  // Run plugin manager hooks
+                  return serverless
+                    .run()
+                    .then(() => {
+                      if (notExecutedLifecycleHookNames.size) {
+                        throw new Error(
+                          `${Array.from(unconfirmedLifecycleHookNames).join(
+                            ', '
+                          )} whitelisted lifecycle hooks were not executed. ` +
+                            'Ensure to enforce desired serverless command via `cliArgs` option.'
+                        );
+                      }
+                      if (hooks.after) return hooks.after(serverless);
+                      return null;
+                    })
+                    .then(() => serverless);
+                });
+              }
+            )
           )
         )
       );


### PR DESCRIPTION
- Replace _whitelist_ approach with _blacklist_ one. Reasoning:
    - Ensuring that all registered hooks are run instead of few picked, makes tests more reliable as it'll pick eventual breaking side effects as introduced by changes to other (not being in scope of given tests) plugins.
    - Additionally it'll make configuration significantly easier. Finding which hooks and plugin should be whitelisted for given scope, to have it properly tested is not trivial in many cases.
- Expose current, resolved context to hooks
