### PR TITLE
runServerless improvements

### DIFF
--- a/configure-aws-request-stub.js
+++ b/configure-aws-request-stub.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const ensureObject = require('type/object/ensure');
+const ensurePlainObject = require('type/plain-object/ensure');
+const ensureFunction = require('type/plain-function/ensure');
+const sinon = require('sinon');
+
+module.exports = (provider, config) => {
+  ensureObject(provider);
+  ensureFunction(provider.request);
+  ensurePlainObject(config);
+
+  if (provider.request.restore) provider.request.restore();
+
+  return sinon.stub(provider, 'request').callsFake(
+    (service, method) =>
+      new Promise((resolve, reject) => {
+        if (!config[service] || !config[service][method]) {
+          reject(new Error(`Missing AWS request stub configuration for ${service}.${method}`));
+          return;
+        }
+        resolve(config[service][method]);
+      })
+  );
+};

--- a/docs/configure-aws-request-stub.md
+++ b/docs/configure-aws-request-stub.md
@@ -1,0 +1,18 @@
+# configure-aws-request-stub
+
+An utility that helps to configure AWS request stubs.
+
+To be set on Framework's AWS `provider` object
+
+Takes `provider` instance, and sets a setup, which returns preconfigured by map responses
+
+```javascript
+const configureAwsRequestStub = require('@serverless/test/configure-aws-request-stub');
+
+configureAwsRequestStub(awsProvider, {
+  CloudFormation: {
+    // Return { StackResourceDetail: {} } for CloudFormation.describeStackResource request
+    describeStackResource: { StackResourceDetail: {} },
+  },
+});
+```

--- a/docs/run-serverless.md
+++ b/docs/run-serverless.md
@@ -72,7 +72,7 @@ When provided, then `serverless.getProvider('aws').request` will be stubbed, and
 
 See [configure-aws-request-stub](./configure-aws-request-stub.md) for more info
 
-#### `modulesCacheStup` (optional)
+#### `modulesCacheStub` (optional)
 
 When provided, serverless instance will be created out of freshly required module,
 and provided cache map will be used as stub for underlying required modules.

--- a/docs/run-serverless.md
+++ b/docs/run-serverless.md
@@ -72,6 +72,14 @@ When provided, then `serverless.getProvider('aws').request` will be stubbed, and
 
 See [configure-aws-request-stub](./configure-aws-request-stub.md) for more info
 
+#### `shouldStubSpawn`
+
+Whether spawn command executions (as configured through `child-process-ext/spawn`) should be stubbed (so not really executed).
+
+Stub is preconfigured to resolve successfully with `{}` (an empty object).
+
+Note: It implies relying on `modulesCacheStub`, so all serverless framework modules will be freshly required.
+
 #### `modulesCacheStub` (optional)
 
 When provided, serverless instance will be created out of freshly required module,

--- a/docs/run-serverless.md
+++ b/docs/run-serverless.md
@@ -62,6 +62,10 @@ Path can be absolute or relative against `serverlessPath`.
 
 List of lifecycle hooks for which callbacks should not be run.
 
+#### `lastLifecycleHookName`
+
+Name of the last lifecycle hook to be run. Registered hooks for all following evens will be discarded
+
 #### `modulesCacheStup` (optional)
 
 When provided, serverless instance will be created out of freshly required module,

--- a/docs/run-serverless.md
+++ b/docs/run-serverless.md
@@ -66,6 +66,12 @@ List of lifecycle hooks for which callbacks should not be run.
 
 Name of the last lifecycle hook to be run. Registered hooks for all following evens will be discarded
 
+#### `awsRequestStubMap`
+
+When provided, then `serverless.getProvider('aws').request` will be stubbed, and provided response map will ensure expected responses.
+
+See [configure-aws-request-stub](./configure-aws-request-stub.md) for more info
+
 #### `modulesCacheStup` (optional)
 
 When provided, serverless instance will be created out of freshly required module,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "log": "^6.0.0",
     "log-node": "^7.0.0",
     "minimist": "^1.2.5",
+    "ncjsm": "^4.0.1",
     "p-limit": "^2.3.0",
     "process-utils": "^3.1.0",
     "sinon": "^8.1.1",

--- a/run-serverless.js
+++ b/run-serverless.js
@@ -13,6 +13,7 @@ const overrideArgv = require('process-utils/override-argv');
 const resolveEnv = require('./resolve-env');
 const disableServerlessStatsRequests = require('./disable-serverless-stats-requests');
 const provisionTmpDir = require('./provision-tmp-dir');
+const configureAwsRequestStub = require('./configure-aws-request-stub');
 
 const resolveServerless = (serverlessPath, modulesCacheStub, callback) => {
   if (!modulesCacheStub) {
@@ -66,6 +67,7 @@ module.exports = (
     pluginPathsBlacklist,
     lifecycleHookNamesBlacklist,
     lastLifecycleHookName,
+    awsRequestStubMap,
     modulesCacheStub,
     hooks = {},
   }
@@ -130,6 +132,7 @@ module.exports = (
     ensureItem: ensureString,
     errorMessage: 'Expected `envWhitelist` to be a var names collection, received %v',
   });
+  awsRequestStubMap = ensurePlainObject(awsRequestStubMap, { isOptional: true });
   return resolveCwd({ cwd, config }).then((confirmedCwd) =>
     overrideEnv({ variables: Object.assign(resolveEnv(), env), whitelist: envWhitelist }, () => {
       return overrideCwd(confirmedCwd, () =>
@@ -216,6 +219,10 @@ module.exports = (
                       };
                       return eventHooks;
                     };
+                  }
+
+                  if (awsRequestStubMap) {
+                    configureAwsRequestStub(serverless.getProvider('aws'), awsRequestStubMap);
                   }
 
                   // Run plugin manager hooks

--- a/run-serverless.js
+++ b/run-serverless.js
@@ -161,7 +161,6 @@ module.exports = (
                     );
                     return serverless.init().then(() => {
                       const { pluginManager } = serverless;
-                      // Strip registered hooks, so only those intended are executed
                       const blacklistedPlugins = pluginManager.plugins.filter((plugin) =>
                         pluginConstructorsBlacklist.some((Plugin) => plugin instanceof Plugin)
                       );


### PR DESCRIPTION
### Utils:
- `configureAwsRequestStub` - Stub AWS requests with preconfigured mocks map

### `runServerless` options:
- `lastLifecycleHookName` option (allows to stop lifecycle engine at some point)
- `awsRequestStubMap` option to automate stubbing of AWS requests
- `shouldStubSpawn` option, to make any child_process spawn's, as made via `child-process-ext/spawn` ineffective.

Additionally ensure no sync exceptions in `runServerless` util
