### PR TITLE
`restore-env` mocha setup extension

### DIFF
--- a/docs/setup/restore-env.md
+++ b/docs/setup/restore-env.md
@@ -1,0 +1,15 @@
+# restore-env
+
+After each top level test run restores `process.env` to state from begin of test run
+
+## Setup
+
+Ensure it's loaded via mocha `require` option, as configured in `package.json`:
+
+```json
+{
+  "mocha": {
+    "require": ["@serverless/test/setup/restore-env"]
+  }
+}
+```

--- a/setup/restore-env.js
+++ b/setup/restore-env.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { deferredRunner } = require('./mocha-reporter');
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+const startEnv = Object.assign(Object.create(null), process.env);
+deferredRunner.then(runner =>
+  runner.on('suite end', suite => {
+    if (!suite.parent || !suite.parent.root) return; // Apply just on top level suites
+    for (const key of Object.keys(process.env)) {
+      if (!(key in startEnv)) delete process.env[key];
+    }
+    for (const key of Object.keys(startEnv)) {
+      if (!hasOwnProperty.call(process.env, key) || process.env[key] !== startEnv[key]) {
+        process.env[key] = startEnv[key];
+      }
+    }
+  })
+);


### PR DESCRIPTION
When debugging windows Ci fail: https://travis-ci.org/serverless/serverless/jobs/623668512

I've found out that some tests leave `process.env` altered. It may influence the test results in tests that follow (it might that it's the reason behind above CI fail).

Like we already have `restoreCwd` util, that reverts eventually changed `cwd` to initial state.
This PR introduces `restoreEnv` util, that does same to `process.env`