### PR TITLE
Support custom concurrency in Mocha Isolated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.2.0](https://github.com/serverless/test/compare/v3.1.0...v3.2.0) (2019-12-13)
+
+### Features
+
+- **Mocha Isolated:** Allow to customize number of workers ([cd9892a](https://github.com/serverless/test/commit/cd9892a2f282dceab0e47d57b3e7865db61d4dc5))
+
 ## [3.1.0](https://github.com/serverless/test/compare/v3.0.0...v3.1.0) (2019-12-12)
 
 ### Features

--- a/bin/mocha-isolated.js
+++ b/bin/mocha-isolated.js
@@ -2,9 +2,7 @@
 
 'use strict';
 
-process.on('unhandledRejection', err => {
-  throw err;
-});
+require('essentials');
 
 const spawn = require('child-process-ext/spawn');
 const chalk = require('chalk');

--- a/bin/mocha-isolated.js
+++ b/bin/mocha-isolated.js
@@ -129,4 +129,4 @@ const run = path => {
 };
 
 const limit = pLimit(processesCount);
-return initialSetupDeferred.then(() => Promise.all(paths.map(path => limit(() => run(path)))));
+initialSetupDeferred.then(() => Promise.all(paths.map(path => limit(() => run(path)))));

--- a/docs/bin/mocha-isolated.md
+++ b/docs/bin/mocha-isolated.md
@@ -4,10 +4,10 @@ Runs each test file in new distinct node.js process, supports below options and 
 
 _Note: it doesn't support or passes through any options to Mocha. it is expected that they're secured at configuration file level_
 
-##### _`--skip-fs-cleanup-check`_
-
-Do not validate file system side effects (this also effectively turns on parallel test run, as file system validation to be reliable requires consecutive run)
-
 ##### _`--pass-through-aws-creds`_
 
 Isolated tests by default are run with no (but mandatory a `PATH`) env variables, and that also includes eventual `AWS_*` env vars. This setting will ensure they're passed through
+
+##### _`--skip-fs-cleanup-check`_
+
+Do not validate file system side effects (this also effectively turns on parallel test run, as file system validation to be reliable requires consecutive run)

--- a/docs/bin/mocha-isolated.md
+++ b/docs/bin/mocha-isolated.md
@@ -4,9 +4,17 @@ Runs each test file in new distinct node.js process, supports below options and 
 
 _Note: it doesn't support or passes through any options to Mocha. it is expected that they're secured at configuration file level_
 
+##### _`--bail` or `-b`_
+
+Gently bail after first test fail
+
 ##### _`--pass-through-aws-creds`_
 
 Isolated tests by default are run with no (but mandatory a `PATH`) env variables, and that also includes eventual `AWS_*` env vars. This setting will ensure they're passed through
+
+##### _`--recursive`_
+
+`--recursive` Mocha option (passed through to Mocha process)
 
 ##### _`--skip-fs-cleanup-check`_
 

--- a/docs/bin/mocha-isolated.md
+++ b/docs/bin/mocha-isolated.md
@@ -8,6 +8,10 @@ _Note: it doesn't support or passes through any options to Mocha. it is expected
 
 Gently bail after first test fail
 
+##### _`--max-workers` or `-w`_
+
+Maximum allowed number of workers for concurrent run
+
 ##### _`--pass-through-aws-creds`_
 
 Isolated tests by default are run with no (but mandatory a `PATH`) env variables, and that also includes eventual `AWS_*` env vars. This setting will ensure they're passed through

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lodash": "^4.17.15",
     "log": "^6.0.0",
     "log-node": "^7.0.0",
+    "minimist": "^1.2.0",
     "p-limit": "^2.2.1",
     "process-utils": "^3.0.1",
     "sinon": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/test",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Test utilities for serverless libraries",
   "repository": "serverless/test",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "chalk": "^2.4.2",
     "child-process-ext": "^2.1.0",
     "cli-progress-footer": "^1.1.1",
+    "essentials": "^1.1.1",
     "fs-extra": "^8.1.0",
     "lodash": "^4.17.15",
     "log": "^6.0.0",


### PR DESCRIPTION
I've noticed that Travis in [serverless](https://github.com/serverless/serverless/) always runs integration tests one by one (no concurrent runs). It's due to fact, that only one CPU core is provided for test run (so technically it behaves as expected).

Still in case of this tests we do a lot of network calls, so introducing a concurrency will definitely speed up a build time, which becomes quite long (we already reached maximum allowed time of 50 minutes by Travis: https://travis-ci.org/serverless/serverless/jobs/624151922)

Before splitting tests into multiple jobs, it'll be good to explore how things will get improved with enforced concurrency, and this patch will allow us to configure that.

--- 

Additionally improved `moha-isolated` setup with `minimist`, and included a release commit
