### PR TITLE
Fix accidentally broken CLI args validation in mocha-isolated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.2.1](https://github.com/serverless/test/compare/v3.2.0...v3.2.1) (2019-12-13)
+
+### Bug Fixes
+
+- **Mocha Isolated:** Ensure to validate options not path arguments ([770d171](https://github.com/serverless/test/commit/770d171688b6fd9520aeda0a556064e344e1926d))
+
 ## [3.2.0](https://github.com/serverless/test/compare/v3.1.0...v3.2.0) (2019-12-13)
 
 ### Features

--- a/bin/mocha-isolated.js
+++ b/bin/mocha-isolated.js
@@ -16,6 +16,7 @@ const argv = require('minimist')(process.argv.slice(2), {
   ],
   alias: { 'help': 'h', 'version': 'v', 'max-workers': 'w' },
   unknown: arg => {
+    if (arg[0] !== '-') return;
     process.stdout.write(chalk.red.bold(`Unrecognized option ${arg}\n\n`));
     process.exit(1);
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/test",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Test utilities for serverless libraries",
   "repository": "serverless/test",
   "keywords": [


### PR DESCRIPTION
Didn't expose when no path arguments were passed.