### PR TITLE
Logs: Ensure timestamps by logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.3.0](https://github.com/serverless/test/compare/v3.2.2...v3.3.0) (2019-12-20)
+
+### Features
+
+- **Log:** Ensure timestamps by logs ([bc268d0](https://github.com/serverless/test/commit/bc268d08652805610abd186e8d086be5ce0bc798))
+
 ### [3.2.2](https://github.com/serverless/test/compare/v3.2.1...v3.2.2) (2019-12-13)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/test",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Test utilities for serverless libraries",
   "repository": "serverless/test",
   "keywords": [

--- a/setup/log.js
+++ b/setup/log.js
@@ -1,5 +1,7 @@
 'use strict';
 
+if (!process.env.LOG_TIME) process.env.LOG_TIME = 'abs';
+
 const log = require('log').get('mocha');
 const initializeLogWriter = require('log-node');
 const { deferredRunner } = require('./mocha-reporter');


### PR DESCRIPTION
For CI fails investigation it's also great to know the exact time at which given event happen, and timespan between events.

This patch ensures timestamps will be exposed.
