### PR TITLE
Dashboard related improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.4.0](https://github.com/serverless/test/compare/v3.3.1...v3.4.0) (2020-01-13)
+
+### Features
+
+- `awsRequest` util ([85f9a84](https://github.com/serverless/test/commit/85f9a84c00e9b41fd36ba8a9ff235d5c917440cd))
+- Recognize dashboard test setup env vars ([69659bf](https://github.com/serverless/test/commit/69659bf3fb0b4a9271916170047df13b32567eb2))
+
 ### [3.3.1](https://github.com/serverless/test/compare/v3.3.0...v3.3.1) (2020-01-10)
 
 ### Bug Fixes

--- a/aws-request.js
+++ b/aws-request.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const _ = require('lodash');
+const AWS = require('aws-sdk');
+const awsLog = require('log').get('aws');
+const wait = require('timers-ext/promise/sleep');
+
+const getServiceInstance = _.memoize(
+  nameInput => {
+    const params = Object.assign({ region: 'us-east-1' }, nameInput.params);
+    const name = typeof nameInput === 'string' ? nameInput : nameInput.name;
+    const Service = _.get(AWS, name);
+    return new Service(params);
+  },
+  nameInput => {
+    return typeof nameInput === 'string' ? nameInput : JSON.stringify(nameInput);
+  }
+);
+
+let lastAwsRequestId = 0;
+module.exports = function awsRequest(service, method, ...args) {
+  const requestId = ++lastAwsRequestId;
+  awsLog.debug('[%d] %o %s %O', requestId, service, method, args);
+  const instance = getServiceInstance(service);
+  return instance[method](...args)
+    .promise()
+    .then(
+      result => {
+        awsLog.debug('[%d] %O', requestId, result);
+        return result;
+      },
+      error => {
+        awsLog.debug('[%d] %O', requestId, error);
+        if (error.statusCode !== 403 && error.retryable) {
+          awsLog.debug('[%d] retry', requestId);
+          return wait(4000 + Math.random() * 3000).then(() => awsRequest(service, method, ...args));
+        }
+        throw error;
+      }
+    );
+};

--- a/docs/aws-request.md
+++ b/docs/aws-request.md
@@ -1,0 +1,38 @@
+# aws-request
+
+Issue AWS SDK request with built-in retry (on retryable errors) mechanism.
+
+## Usage
+
+```javascript
+awsRequest(serviceNameOrConfig, methodName, params);
+```
+
+### `serviceNameOrConfig`
+
+Service name (e.g. `'CloudFormation'`), or a config, if we need to pass a parameters to contrusctors, e.g.:
+
+```javascript
+{
+  "name": "CloudFormation",
+  "params": {
+    "region": "us-east-2" // Override 'us-east-1' default
+  }
+}
+```
+
+### `methodName`
+
+Given service method name e.g. `describeStacks`
+
+### `params`
+
+Invocation params, passed as direct input to AWS SDK method.
+
+## Example:
+
+```javascript
+const awsRequest = require('@serverless/test/aws-request');
+
+const result = await awsRequest('CloudFormation', 'describeStacks', { StackName: stackName });
+```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "mocha-isolated": "./bin/mocha-isolated.js"
   },
   "dependencies": {
-    "aws-sdk": "^2.600.0",
+    "aws-sdk": "^2.601.0",
     "chalk": "^2.4.2",
     "child-process-ext": "^2.1.0",
     "cli-progress-footer": "^1.1.1",
@@ -33,11 +33,11 @@
     "@serverless/eslint-config": "^1.2.1",
     "bluebird": "^3.7.2",
     "eslint": "^6.8.0",
-    "eslint-plugin-import": "^2.19.1",
+    "eslint-plugin-import": "^2.20.0",
     "git-list-updated": "^1.2.1",
     "github-release-from-cc-changelog": "^2.2.0",
     "glob-exec": "^0.1.1",
-    "husky": "^4.0.6",
+    "husky": "^4.0.7",
     "lint-staged": "^9.5.0",
     "mocha": "^6.2.2",
     "prettier": "^1.19.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "mocha-isolated": "./bin/mocha-isolated.js"
   },
   "dependencies": {
+    "aws-sdk": "^2.600.0",
     "chalk": "^2.4.2",
     "child-process-ext": "^2.1.0",
     "cli-progress-footer": "^1.1.1",
@@ -24,6 +25,7 @@
     "p-limit": "^2.2.2",
     "process-utils": "^3.0.1",
     "sinon": "^8.0.4",
+    "timers-ext": "^0.1.7",
     "type": "^2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/test",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Test utilities for serverless libraries",
   "repository": "serverless/test",
   "keywords": [

--- a/resolve-aws-env.js
+++ b/resolve-aws-env.js
@@ -3,7 +3,13 @@
 const resolveEnv = require('./resolve-env');
 
 module.exports = () => {
-  const env = resolveEnv({ whitelist: ['SERVERLESS_ACCESS_KEY'] });
+  const env = resolveEnv({
+    whitelist: [
+      'SERVERLESS_ACCESS_KEY',
+      'SERVERLESS_PLATFORM_TEST_APP',
+      'SERVERLESS_PLATFORM_TEST_ORG',
+    ],
+  });
   for (const envVarName of Object.keys(process.env)) {
     if (envVarName.startsWith('AWS_')) env[envVarName] = process.env[envVarName];
   }

--- a/resolve-aws-env.js
+++ b/resolve-aws-env.js
@@ -3,12 +3,9 @@
 const resolveEnv = require('./resolve-env');
 
 module.exports = () => {
-  const env = resolveEnv();
+  const env = resolveEnv({ whitelist: ['SERVERLESS_ACCESS_KEY'] });
   for (const envVarName of Object.keys(process.env)) {
     if (envVarName.startsWith('AWS_')) env[envVarName] = process.env[envVarName];
-  }
-  if (process.env.SERVERLESS_ACCESS_KEY) {
-    env.SERVERLESS_ACCESS_KEY = process.env.SERVERLESS_ACCESS_KEY;
   }
   return env;
 };

--- a/resolve-env.js
+++ b/resolve-env.js
@@ -8,6 +8,7 @@ module.exports = (options = {}) => {
     whitelist: [
       'APPDATA',
       'HOME',
+      'LOCAL_SERVERLESS_LINK_PATH',
       'PATH',
       'SERVERLESS_BINARY_PATH',
       'TMPDIR',

--- a/resolve-env.js
+++ b/resolve-env.js
@@ -2,8 +2,17 @@
 
 const createEnv = require('process-utils/create-env');
 
-module.exports = () =>
-  createEnv({
-    whitelist: ['APPDATA', 'HOME', 'PATH', 'SERVERLESS_BINARY_PATH', 'TMPDIR', 'USERPROFILE'],
-    variables: { SLS_TRACKING_DISABLED: '1' },
+module.exports = (options = {}) => {
+  if (!options) options = {};
+  return createEnv({
+    whitelist: [
+      'APPDATA',
+      'HOME',
+      'PATH',
+      'SERVERLESS_BINARY_PATH',
+      'TMPDIR',
+      'USERPROFILE',
+    ].concat(options.whitelist || []),
+    variables: Object.assign({ SLS_TRACKING_DISABLED: '1' }, options.variables || {}),
   });
+};


### PR DESCRIPTION
- Recognize dashboard specific test debug env vars
- Seclude `awsRequest` from [serverless](https://github.com/serverless/serverless/blob/de887ac23a1fbb3f68ea64f16c13c02d75c21932/tests/utils/misc/index.js#L15-L39), so we can rely on it also in `@serverless/enterprise-plugin`