### PR TITLE
CI: Workaround Travis CI issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,6 +140,7 @@ jobs:
           fi
         - npx github-release-from-cc-changelog $TRAVIS_TAG
       deploy:
+        edge: true # Workaorund Travis regression: https://travis-ci.community/t/missing-api-key-when-deploying-to-github-releases/5761
         provider: npm
         email: services@serverless.com
         on:


### PR DESCRIPTION
Deploy failed with `missing api_key` error, while API key is configured https://travis-ci.org/serverless/test/builds/639477577

It appears as known Travis CI  issue, workaround it so add `edge: true` to deploy config.

In a meantime I've published v3.5.0 manually