### PR TITLE
Fix Mocha patches

### DIFF
--- a/setup/mocha-reporter.js
+++ b/setup/mocha-reporter.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { inspect } = require('util');
+
 // Unhandled rejections are not exposed in Mocha, enforce it
 // https://github.com/mochajs/mocha/issues/2640
 process.on('unhandledRejection', err => {
@@ -34,6 +36,10 @@ class ServerlessSpec extends Spec {
         // Mocha ignores uncaught exceptions if they happen in conext of skipped test, expose them
         // https://github.com/mochajs/mocha/issues/3938
         if (runner.currentRunnable.isPending() || runner._abort) throw err; // eslint-disable-line no-underscore-dangle
+        if (runner.currentRunnable.isFailed()) {
+          // Process is guaranteed to fail, still given uncaught exception is not exposed;
+          process.stdout.write(`Uncaught exception: ${inspect(err, { colors: true })}`);
+        }
         return;
       }
       // If there's an uncaught exception after test runner wraps up

--- a/setup/mock-homedir.js
+++ b/setup/mock-homedir.js
@@ -19,7 +19,10 @@ deferredRunner.then(runner => {
       emptyDirSync(processTmpDir);
     } catch (error) {
       if (rmTmpDirIgnorableErrorCodes.has(error.code)) return;
-      throw error;
+      process.nextTick(() => {
+        // Crash in next tick, as otherwise Mocha goes bonkers
+        throw error;
+      });
     }
   });
 });


### PR DESCRIPTION
Run into scenario where test timeout fail propagated few other crashes, and in result provided output was clueless.

This patch ensures that all errors are exposed in such case and process exits with non `0` code