### PR TITLE
Bump timeout in async leaks detector to avoid false positives

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -11,7 +11,15 @@ module.exports = {
     'scope-enum': [
       2,
       'always',
-      ['', 'Inquirer Stub', 'Log', 'Mocha Fixes', 'Mocha Isolated', 'Run Serverless'],
+      [
+        '',
+        'Async Leaks Detector',
+        'Inquirer Stub',
+        'Log',
+        'Mocha Fixes',
+        'Mocha Isolated',
+        'Run Serverless',
+      ],
     ],
     'subject-case': [2, 'always', 'sentence-case'],
     'subject-empty': [2, 'never'],

--- a/setup/async-leaks-detector/index.js
+++ b/setup/async-leaks-detector/index.js
@@ -12,8 +12,8 @@ require('../mocha-reporter').deferredRunner.then(runner =>
       // It's a signal there's some promise chain (or in general async flow) misconfiguration
       process.stdout.write(chalk.red('Error: Test ended with unfinished async jobs\n'));
       process.on('exit', () => (process.exitCode = 1));
-      // Timeout '2' to ensure no false positives, with '1' there are observable rare scenarios
-      // of possibly a garbage collector delaying process exit being picked up
-    }, 5).unref();
+      // Timeout '10' to ensure no false positives, with lower values there are observable rare
+      // scenarios of possibly a garbage collector delaying process exit being picked up
+    }, 10).unref();
   })
 );


### PR DESCRIPTION
False positive was observed in this CI fail: https://travis-ci.com/serverless/enterprise-plugin/jobs/289444390