### PR TITLE
Mocha `hasFailed` util

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -16,6 +16,7 @@ module.exports = {
         'Async Leaks Detector',
         'Inquirer Stub',
         'Log',
+        'Mocha',
         'Mocha Fixes',
         'Mocha Isolated',
         'Run Serverless',

--- a/docs/has-failed.md
+++ b/docs/has-failed.md
@@ -1,0 +1,17 @@
+# has-failed
+
+Answers whether any tests in passed suite failed. Useful when we want to abort cleanup in `after`
+after a test fail, to enable further investigation.
+
+```javascript
+const hasFailed = require('@serverless/test/has-failed');
+
+describe('Some suite', () => {
+  after(function () {
+    if (hasFailed(this.test.parent)) return; // Avoid cleanup
+    // .. cleanup ..
+  });
+
+  // Tests
+});
+```

--- a/has-failed.js
+++ b/has-failed.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = (suite) => {
+  if (suite.tests.some((test) => test.state === 'failed')) return true;
+  return suite.suites.some(module.exports);
+};


### PR DESCRIPTION
Answers whether any tests in passed suite failed. Useful when we want to abort cleanup in after after a test fail, to enable further investigation.
