### PR TITLE
Run Serverless: Mute stdout and expose at stdoutData

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,9 +3,7 @@
 module.exports = {
   rules: {
     'body-leading-blank': [2, 'always'],
-    'body-max-line-length': [2, 'always', 72],
     'footer-leading-blank': [2, 'always'],
-    'footer-max-line-length': [2, 'always', 72],
     'header-max-length': [2, 'always', 72],
     'scope-case': [2, 'always', 'start-case'],
     'scope-enum': [

--- a/docs/run-serverless.md
+++ b/docs/run-serverless.md
@@ -13,7 +13,7 @@ describe('Some suite', () => {
   it('Some test that involves creation of serverless instance', function () {
     runServerless(serverlessPath, {
       // Options, see below documentation
-    }).then((serverless) => {
+    }).then(({ serverless, stdoutData }) => {
       // Resolved after serverless.run() finalizes.
       // Examine here expected outcome
     });
@@ -102,3 +102,8 @@ It's invoked with `Serverless` constructor and resolved `cwd` as meta data in ar
 Run as last step of evaluation (after `serverless.run()` resolves).
 
 It's invokved with `serverless` instance passed as first argument
+
+### Result values
+
+- `serverless` - Instance of Serverless Framework
+- `stdoutData` - Written data to `process.stdout`


### PR DESCRIPTION
Comes with a breaking change, as `runServerless` no longer resolves `serverless` instance directly. Now data object is returned with `serverless` and `stdoutData` properties