### PR TITLE
Feature: Allow functions as AWS provider request stubs.

### DIFF
--- a/configure-aws-request-stub.js
+++ b/configure-aws-request-stub.js
@@ -19,7 +19,9 @@ module.exports = (provider, config) => {
           reject(new Error(`Missing AWS request stub configuration for ${service}.${method}`));
           return;
         }
-        resolve(config[service][method]);
+
+        const meth = config[service][method];
+        resolve(typeof meth === 'function' ? meth() : meth);
       })
   );
 };

--- a/configure-aws-request-stub.js
+++ b/configure-aws-request-stub.js
@@ -13,15 +13,15 @@ module.exports = (provider, config) => {
   if (provider.request.restore) provider.request.restore();
 
   return sinon.stub(provider, 'request').callsFake(
-    (service, method) =>
+    (service, methodName, ...args) =>
       new Promise((resolve, reject) => {
-        if (!config[service] || !config[service][method]) {
-          reject(new Error(`Missing AWS request stub configuration for ${service}.${method}`));
+        if (!config[service] || !config[service][methodName]) {
+          reject(new Error(`Missing AWS request stub configuration for ${service}.${methodName}`));
           return;
         }
 
-        const meth = config[service][method];
-        resolve(typeof meth === 'function' ? meth() : meth);
+        const method = config[service][methodName];
+        resolve(typeof method === 'function' ? method(...args) : method);
       })
   );
 };

--- a/docs/configure-aws-request-stub.md
+++ b/docs/configure-aws-request-stub.md
@@ -4,7 +4,7 @@ An utility that helps to configure AWS request stubs.
 
 To be set on Framework's AWS `provider` object
 
-Takes `provider` instance, and sets a setup, which returns preconfigured by map responses
+Takes `provider` instance, and sets a setup, which returns preconfigured by map responses. Values can be scalars or functions (including `sinon.stub`, etc.).
 
 ```javascript
 const configureAwsRequestStub = require('@serverless/test/configure-aws-request-stub');


### PR DESCRIPTION
Per discussion at https://github.com/serverless/serverless/pull/8351#issuecomment-705826049 this change will allow AWS request stubs to be either scalars or functions allowing use cases like:

```js
runServerless({
  // ...
  awsRequestStubMap: {
    // ...
    S3: {
      // **NEW**: Allow different responses for different calls!
      headObject: sandbox.stub()
        .onCall(0).returns({
          Metadata: { filesha256: 'FIRST_VALUE' }
        })
        .onCall(1).returns({
          Metadata: { filesha256: 'SECOND_VALUE' }
        }),
      // **OLD**: Scalars still work
      listObjectsV2: {
        Contents: [
          {
            Key:
              'serverless/test-package-artifact/dev/1589988704359-2020-05-20T15:31:44.359Z/compiled-cloudformation-template.json',
            LastModified: new Date(),
            ETag: '"5102a4cf710cae6497dba9e61b85d0a4"',
            Size: 356,
            StorageClass: 'STANDARD',
          },
          {
            Key:
              'serverless/test-package-artifact/dev/1589988704359-2020-05-20T15:31:44.359Z/my-own.zip',
            LastModified: new Date(),
            ETag: '"5102a4cf710cae6497dba9e61b85d0a4"',
            Size: 356,
            StorageClass: 'STANDARD',
          },
        ],
      },
    },
    // ...
  },
})
```