### PR TITLE
Recognize EBUSY as safe to ignore on cleanup of tmp dir

### DIFF
--- a/lib/private/rm-tmp-dir-ignorable-error-codes.js
+++ b/lib/private/rm-tmp-dir-ignorable-error-codes.js
@@ -3,4 +3,4 @@
 // Removal temporary directory reported occassional crashes on Winodws (in CI)
 // It's just a cleanup operation, so failure is safe to ignore
 // Exported set, lists all error codes we recognize as safe to ignore
-module.exports = new Set(['EPERM']);
+module.exports = new Set(['EBUSY', 'EPERM']);


### PR DESCRIPTION
Observed, after recent changes, in Windows CI build: https://github.com/serverless/serverless/pull/8428/checks?check_run_id=1297905115