### PR TITLE
Mocha Fixes: Fix tests propagation patch

### DIFF
--- a/setup/mocha-reporter.js
+++ b/setup/mocha-reporter.js
@@ -11,16 +11,21 @@ process.on('unhandledRejection', (err) => {
 const Spec = require('mocha/lib/reporters/spec');
 const Runner = require('mocha/lib/runner');
 
-// Ensure faster tests propagation
-// It's to expose errors otherwise hidden by race conditions
-// Reported to Mocha with: https://github.com/mochajs/mocha/issues/3920
-Runner.immediately = process.nextTick;
-
 let resolveRunner;
 class ServerlessSpec extends Spec {
   constructor(runner) {
     super(runner);
     resolveRunner(runner);
+    process.nextTick(() => {
+      // Ensure faster tests propagation
+      // It's to expose errors otherwise hidden by race conditions
+      // Reported to Mocha with: https://github.com/mochajs/mocha/issues/3920
+      //
+      // Override needs to be done in next tick to ensure other Mocha extensions attach to resolved
+      // runner before any tests are being run
+      // (Race condition was observed, in which `runner` was resolved afterwards)
+      Runner.immediately = process.nextTick;
+    });
 
     process.on('uncaughtException', (err) => {
       if (


### PR DESCRIPTION
Fix, to workaround race condition as diagnosed at https://github.com/serverless/serverless/pull/8413#issuecomment-732265708 (cc @pgrzesik)

Interestingly, in some race condition scenarios `then` callbacks as attached to [`deferredRunner`](https://github.com/serverless/test/blob/2deb709ada86ec400c8d2358a14c37adf5bd25ee/setup/mocha-reporter.js#L52)
are propagated after first test is being executed (it's influenced by patch  which changes scheduling of tests to be propagated via `process.nextTick` instead of `setImmediate`).

It most likely goes down to how V8 propagates promises callbacks, which can differ in some scenarios, e.g. when invoking mocha via `npx` (as `npx mocha test.js`), the promise callbacks were propagated before first test, while when invoking the mocha binary directly (via `node node_modules/.bin/mocha test.js`) it's no longer the case.

This fix ensures that we override scheduler with `process.nextTick` in tick after we resolve promise. This guarantees that in all cases `then` callbacks will be propagated before test run.

