### PR TITLE
feat(Mocha): Patch circular references parallel invocation bug

### DIFF
--- a/setup/patch.js
+++ b/setup/patch.js
@@ -10,11 +10,39 @@ const EventEmitter = require('events');
 
 const runnerEmitter = new EventEmitter();
 
+const isObject = require('type/object/is');
 const Mocha = require('mocha/lib/mocha');
+const { serialize } = require('mocha/lib/nodejs/serializer');
+
+const removeCyclicReferences = (object, parentObjects = new Set()) => {
+  const entries = Array.isArray(object) ? object.entries() : Object.entries(object);
+  parentObjects = new Set([...parentObjects, object]);
+  for (const [key, value] of entries) {
+    if (!isObject(value)) continue;
+    if (parentObjects.has(value)) delete object[key];
+    else removeCyclicReferences(value, parentObjects);
+  }
+};
 
 const mochaRun = Mocha.prototype.run;
 Mocha.prototype.run = function (fn, ...args) {
-  const runner = mochaRun.call(this, fn, ...args);
+  const runner = mochaRun.call(
+    this,
+    (result) => {
+      // Workaround https://github.com/mochajs/mocha/issues/4552
+      const serialized = serialize(result);
+      const stringifiedResult = (() => {
+        try {
+          return JSON.stringify(serialized);
+        } catch (error) {
+          removeCyclicReferences(serialized);
+          return JSON.stringify(serialized);
+        }
+      })();
+      return fn.call(this, JSON.parse(stringifiedResult));
+    },
+    ...args
+  );
   if (runner.constructor.name === 'Runner') runnerEmitter.emit('runner', runner);
   runner.constructor.immediately = process.nextTick;
   return runner;


### PR DESCRIPTION
Workaround for https://github.com/mochajs/mocha/issues/4552 

This patch ensures that eventual circular references in array won't crash Mocha in parallel mode. It won't prevent hang in case error cross-references to its own instance, but I take we don't have to worry about this scenario at this point.

Confirmed to have no effect when no _parallel_ processing is applied