### PR TITLE
Mocha: Log test error right when it happens

### DIFF
--- a/setup/log.js
+++ b/setup/log.js
@@ -36,6 +36,8 @@ const logsBuffer = [];
 const flushLogs = () => {
   // Write, only if there are some non-mocha log events
   if (logsBuffer.some((event) => event.logger.namespace !== 'mocha')) {
+    log.notice('flushing previously gathered logs...');
+    logsBuffer.pop(); // Drop above log from logsBuffer
     logsBuffer.forEach((event) => {
       if (!event.message) logWriter.resolveMessage(event);
       logWriter.writeMessage(event);
@@ -54,7 +56,11 @@ runnerEmitter.on('runner', (runner) => {
 
     logsBuffer.length = 0; // Empty array
   });
-  runner.on('fail', flushLogs);
+  runner.on('fail', (ignore, error) => {
+    log.error('test fail %s', error && error.stack);
+    logsBuffer.pop(); // Drop above log from logsBuffer
+    flushLogs();
+  });
 });
 
 module.exports.flushLogs = flushLogs;


### PR DESCRIPTION
We're battling the error that happens in CI environment, and recently it went without stack trace being logged. Simply because Mocha logs stack trace only in final summary, and it appears that process was terminated before that summary was printed.

(CI fail in question: https://github.com/serverless/serverless/runs/1813369649)

This patch ensures that test fail is logged right when it happens and is registered by Mocha as fail.