### PR TITLE
feat: Ensure monitoring frequency is low to speed up tests

### DIFF
--- a/run-serverless.js
+++ b/run-serverless.js
@@ -165,7 +165,10 @@ module.exports = async (
     }
   })();
   return overrideEnv(
-    { variables: Object.assign(resolveEnv(), env), whitelist: envWhitelist },
+    {
+      variables: Object.assign(resolveEnv(), { SLS_AWS_MONITORING_FREQUENCY: '1' }, env),
+      whitelist: envWhitelist,
+    },
     () => {
       let stdoutData = '';
       return overrideCwd(confirmedCwd, () =>


### PR DESCRIPTION
I've noticed that all tests that depend on calling `monitorStack` in `serverless/serverless` are taking longer time due to the fact that default value of monitoring frequency is set to 5 seconds (so they will take at least 5 seconds extra for each call to `monitorStack`). Reference: https://github.com/serverless/serverless/blob/a11a43c5d2d770ca2df849408dad10fe6de95c38/lib/plugins/aws/lib/monitorStack.js#L17