### PR TITLE
Ensure to expose real tmp dir path

### DIFF
--- a/process-tmp-dir.js
+++ b/process-tmp-dir.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const { mkdirSync } = require('fs');
+const { mkdirSync, realpathSync } = require('fs');
 const { removeSync } = require('fs-extra');
 const path = require('path');
 const os = require('os');
 const crypto = require('crypto');
 const rmTmpDirIgnorableErrorCodes = require('./lib/private/rm-tmp-dir-ignorable-error-codes');
 
-const systemTmpDir = os.tmpdir();
+const systemTmpDir = realpathSync(os.tmpdir());
 const serverlessTmpDir = path.join(systemTmpDir, 'tmpdirs-serverless');
 try {
   mkdirSync(serverlessTmpDir);


### PR DESCRIPTION
In some systems (as macOS) `os.tmpdir()` points symlinked path, relying on which may raise issues in some testing scenarios (e.g. when confirming on path).

Recently with extensions to lambda image support, we've added tests that confirm on tmp path, and I found them failing on macOS as:

<img width="683" alt="Screenshot 2021-02-09 at 13 58 25" src="https://user-images.githubusercontent.com/122434/107366868-ea3bbe80-6ade-11eb-8f00-a6cade5508a0.png">

It's due to `os.tmpdir()` resolving `/var/folders/...` path to tmpdir, while `/var` on macOS is a symlink to `/private/var`.

This patch ensures we always work with real paths when tmp dirs are concerned