### PR TITLE
Run Serverless: Adapt to a new CLI parser

### DIFF
--- a/run-serverless.js
+++ b/run-serverless.js
@@ -185,11 +185,11 @@ module.exports = async (
                 // Intialize serverless instances in preconfigured environment
                 const configurationPath = resolveConfigurationPath
                   ? await resolveConfigurationPath()
-                  : null;
+                  : undefined;
                 const configuration =
                   configurationPath && readConfiguration
                     ? await readConfiguration(configurationPath)
-                    : null;
+                    : undefined;
                 let serverless = new Serverless({ configurationPath, configuration });
                 if (serverless.triggeredDeprecations) {
                   serverless.triggeredDeprecations.clear();

--- a/run-serverless.js
+++ b/run-serverless.js
@@ -150,6 +150,7 @@ module.exports = async (
   }
   const confirmedCwd = await resolveCwd({ cwd, config });
 
+  // TODO: Remove try/catch conditionals with next major release
   const resolveConfigurationPath = (() => {
     try {
       return require(path.resolve(serverlessPath, 'lib/cli/resolve-configuration-path'));

--- a/run-serverless.js
+++ b/run-serverless.js
@@ -165,6 +165,16 @@ module.exports = async (
       return null;
     }
   })();
+  const resolveInput = (() => {
+    try {
+      const exports = require(path.resolve(serverlessPath, 'lib/cli/resolve-input'));
+      exports.clear();
+      return exports;
+    } catch {
+      return null;
+    }
+  })();
+
   return overrideEnv(
     {
       variables: Object.assign(resolveEnv(), { SLS_AWS_MONITORING_FREQUENCY: '1' }, env),
@@ -190,7 +200,11 @@ module.exports = async (
                   configurationPath && readConfiguration
                     ? await readConfiguration(configurationPath)
                     : undefined;
-                let serverless = new Serverless({ configurationPath, configuration });
+                let serverless = new Serverless({
+                  configurationPath,
+                  configuration,
+                  ...(resolveInput ? resolveInput() : {}),
+                });
                 if (serverless.triggeredDeprecations) {
                   serverless.triggeredDeprecations.clear();
                 }


### PR DESCRIPTION
Follow up to https://github.com/serverless/serverless/pull/8927. Needed to be merged and released for the https://github.com/serverless/serverless/pull/8927 to pass tests.