### PR TITLE
Release v8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [8.0.0](https://github.com/serverless/test/compare/v7.11.0...v8.0.0) (2021-04-09)
+
+### ⚠ BREAKING CHANGES
+
+- **Run Serverless:** `cliArgs` options was dropped in favor more programmatic `command` and `options`.
+  `runServerless` can only be used with `serverless` which provides `lib/configuration/variables/index.js` util.
+
+### Features
+
+- **Run Serverless:** Replace `cliArgs` with `command` and `options` ([#91](https://github.com/serverless/test/pull/91)) ([37d850b](https://github.com/serverless/test/commit/37d850bff25c2b42db539f8eb5652c7ff7603962)) ([Mariusz Nowak](https://github.com/medikoo))
+
 ## [7.11.0](https://github.com/serverless/test/compare/v7.10.1...v7.11.0) (2021-03-26)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/test",
-  "version": "7.11.0",
+  "version": "8.0.0",
   "description": "Test utilities for serverless libraries",
   "repository": "serverless/test",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "mocha-isolated": "./bin/mocha-isolated.js"
   },
   "dependencies": {
-    "@serverless/utils": "^4.0.0",
-    "aws-sdk": "^2.873.0",
+    "@serverless/utils": "^4.0.1",
+    "aws-sdk": "^2.883.0",
     "bluebird": "^3.7.2",
     "chalk": "^4.1.0",
     "child-process-ext": "^2.1.1",
@@ -29,14 +29,14 @@
     "ncjsm": "^4.1.0",
     "p-limit": "^3.1.0",
     "process-utils": "^4.0.0",
-    "sinon": "^10.0.0",
+    "sinon": "^10.0.1",
     "timers-ext": "^0.1.7",
     "type": "^2.5.0"
   },
   "devDependencies": {
-    "@commitlint/cli": "^12.0.1",
+    "@commitlint/cli": "^12.1.1",
     "@serverless/eslint-config": "^3.0.0",
-    "eslint": "^7.22.0",
+    "eslint": "^7.23.0",
     "eslint-plugin-import": "^2.22.1",
     "git-list-updated": "^1.2.1",
     "github-release-from-cc-changelog": "^2.2.0",
@@ -45,7 +45,7 @@
     "lint-staged": "^10.5.4",
     "mocha": "^8.3.2",
     "prettier": "^2.2.1",
-    "standard-version": "^9.1.1"
+    "standard-version": "^9.2.0"
   },
   "peerDependencies": {
     "mocha": "8"


### PR DESCRIPTION
After merged, will be shortly followed with upgrade PR's to `serverless` and `@serverless/enterprise-plugin`