### PR TITLE
Enforce error deprecations mode

### DIFF
--- a/resolve-env.js
+++ b/resolve-env.js
@@ -14,6 +14,9 @@ module.exports = (options = {}) => {
       'TMPDIR',
       'USERPROFILE',
     ].concat(options.whitelist || []),
-    variables: Object.assign({ SLS_TRACKING_DISABLED: '1' }, options.variables || {}),
+    variables: Object.assign(
+      { SLS_TRACKING_DISABLED: '1', SLS_DEPRECATION_NOTIFICATION_MODE: 'error' },
+      options.variables || {}
+    ),
   });
 };

--- a/setup-fixtures-engine.js
+++ b/setup-fixtures-engine.js
@@ -60,9 +60,9 @@ const setupFixture = memoizee(
             if (!hasSetupScript) return null;
             log.notice('run setup for %s (at %s)', path.basename(fixturePath), setupFixturePath);
             const setupScriptPath = path.resolve(setupFixturePath, '_setup.js');
-            return Promise.resolve(
-              ensurePlainFunction(require(setupScriptPath))(fixturePath)
-            ).then(() => fse.unlink(setupScriptPath));
+            return Promise.resolve(ensurePlainFunction(require(setupScriptPath))(fixturePath)).then(
+              () => fse.unlink(setupScriptPath)
+            );
           })
           .then(() => setupFixturePath);
       });

--- a/setup/patch.js
+++ b/setup/patch.js
@@ -6,6 +6,9 @@ process.on('unhandledRejection', (err) => {
   throw err;
 });
 
+// Ensure no telemetry reporting in tests
+process.env.SLS_TELEMETRY_DISABLED = '1';
+
 const path = require('path');
 const EventEmitter = require('events');
 

--- a/setup/patch.js
+++ b/setup/patch.js
@@ -6,6 +6,9 @@ process.on('unhandledRejection', (err) => {
   throw err;
 });
 
+// By default report deprecations as errors
+process.env.SLS_DEPRECATION_NOTIFICATION_MODE = 'error';
+
 // Ensure no telemetry reporting in tests
 process.env.SLS_TELEMETRY_DISABLED = '1';
 


### PR DESCRIPTION
When new deprecation is introduced, ideally all tests should be updated to not rely on deprecated functionality (unless we're testing it specifically).

Unfortunately, as we didn't have good validation mean to detect such usage, a lot of tests that rely on deprecated functionalities were left not updated.

Now, with https://github.com/serverless/serverless/pull/9623 it'll be possible to have deprecations reported as errors. This PR ensures it'll be the case by default for test run in Serverless projects.

Additionally I've set environment variable guarding telemetry reports not to be send.

In https://github.com/serverless/serverless/pull/9623 and https://github.com/serverless/dashboard-plugin/pull/600 I've ensured that both `serverless` and `dashboard-plugin` are prepared for that change (tested both unit and integration tests)