### PR TITLE
Pass through `LOG_LEVEL` env variable

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -14,20 +14,6 @@ jobs:
     name: '[Linux] Node.js v14: Unit tests'
     runs-on: ubuntu-latest
     steps:
-      - name: Resolve last validated commit hash (for `git diff` purposes)
-        env:
-          # See https://github.com/serverlessinc/setup-cicd-resources
-          GET_LAST_VALIDATED_COMMIT_HASH_URL: ${{ secrets.GET_LAST_VALIDATED_COMMIT_HASH_URL }}
-          PUT_LAST_VALIDATED_COMMIT_HASH_URL: ${{ secrets.PUT_LAST_VALIDATED_COMMIT_HASH_URL }}
-        run: |
-          curl -f "$GET_LAST_VALIDATED_COMMIT_HASH_URL" -o /home/runner/last-validated-commit-hash || :
-          curl -X PUT -H "User-Agent:" -H "Accept:" -H "Content-Type:" -d "$GITHUB_SHA" "$PUT_LAST_VALIDATED_COMMIT_HASH_URL"
-      - name: Store last validated commit hash (as it's to be used in other job)
-        uses: actions/upload-artifact@v2
-        with:
-          name: last-validated-commit-hash
-          path: /home/runner/last-validated-commit-hash
-
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -172,21 +158,11 @@ jobs:
           # Tag needs to be pushed with real user token, otherwise pushed tag won't trigger the actions workflow
           # Hence we're passing 'serverless-ci' user authentication token
           token: ${{ secrets.USER_GITHUB_TOKEN }}
-      - name: Resolve last validated commit hash (for `git diff` purposes)
-        uses: actions/download-artifact@v2
-        continue-on-error: true
-        with:
-          name: last-validated-commit-hash
-          path: /home/runner
       - name: Tag if new version
         run: |
-          LAST_VALIDATED_COMMIT_HASH=`cat /home/runner/last-validated-commit-hash` || :
-          if [ -n "$LAST_VALIDATED_COMMIT_HASH" ];
+          NEW_VERSION=`git diff -U0 ${{ github.event.before }} package.json | grep '"version": "' | tail -n 1 | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"` || :
+          if [ -n "$NEW_VERSION" ];
           then
-            NEW_VERSION=`git diff -U0 $LAST_VALIDATED_COMMIT_HASH package.json | grep '"version": "' | tail -n 1 | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"` || :
-            if [ -n "$NEW_VERSION" ];
-            then
-              git tag v$NEW_VERSION
-              git push --tags
-            fi
+            git tag v$NEW_VERSION
+            git push --tags
           fi

--- a/resolve-env.js
+++ b/resolve-env.js
@@ -9,6 +9,7 @@ module.exports = (options = {}) => {
       'APPDATA',
       'HOME',
       'LOCAL_SERVERLESS_LINK_PATH',
+      'LOG_LEVEL',
       'PATH',
       'SERVERLESS_BINARY_PATH',
       'TMPDIR',


### PR DESCRIPTION
It's helpful when debugging to let all debug logs flow, yet in `mocha-isolated` run `LOG_LEVEL` env var was not passed down stream. This patch fixes that.

Additionally cleanuped up commit range resolution in CI