### PR TITLE
Environment: Allow env vars starting with `SERVERLESS_PLATFORM_`

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -12,6 +12,7 @@ module.exports = {
       [
         '',
         'Async Leaks Detector',
+        'Environment',
         'Fixtures Engine',
         'Inquirer Stub',
         'Log',

--- a/resolve-aws-env.js
+++ b/resolve-aws-env.js
@@ -7,7 +7,7 @@ module.exports = () => {
     whitelist: ['SERVERLESS_ACCESS_KEY', 'SLS_AWS_REQUEST_MAX_RETRIES'],
   });
   for (const envVarName of Object.keys(process.env)) {
-    if (envVarName.startsWith('AWS_') || envVarName.startsWith('SERVERLESS_PLATFORM_TEST_')) {
+    if (envVarName.startsWith('AWS_') || envVarName.startsWith('SERVERLESS_PLATFORM_')) {
       env[envVarName] = process.env[envVarName];
     }
   }


### PR DESCRIPTION
So e.g. `SERVERLESS_PLATFORM_STAGE` is passed through