### PR TITLE
feat: Add schema cache env var to allowlist

### DIFF
--- a/resolve-env.js
+++ b/resolve-env.js
@@ -12,6 +12,7 @@ module.exports = (options = {}) => {
       'LOG_LEVEL',
       'PATH',
       'SERVERLESS_BINARY_PATH',
+      'SLS_SCHEMA_CACHE_BASE_DIR',
       'TMPDIR',
       'USERPROFILE',
     ].concat(options.whitelist || []),


### PR DESCRIPTION
Needed for allowing to tweak the cache directory of compiled schema validation code

Related: https://github.com/serverless/serverless/pull/10429