### PR TITLE
Upgrade dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Provides a reliable test suite setup, based on [Mocha](https://mochajs.org/) tes
 ### Installation
 
 ```bash
-npm i --save-dev mocha@8 chai chai-as-promised @serverless/test
+npm i --save-dev mocha@9 chai chai-as-promised @serverless/test
 ```
 
 ### Mocha Setup

--- a/docs/aws-request.md
+++ b/docs/aws-request.md
@@ -5,16 +5,16 @@ Issue AWS SDK request with built-in retry (on retryable errors) mechanism.
 ## Usage
 
 ```javascript
-awsRequest(serviceNameOrConfig, methodName, params);
+awsRequest(clientOrClientConfig, methodName, params);
 ```
 
-### `serviceNameOrConfig`
+### `clientOrClientConfig`
 
-Service name (e.g. `'CloudFormation'`), or a config, if we need to pass a parameters to contrusctors, e.g.:
+Client constructor (e.g. `require('@aws-sdk/client-cloudformation').CloudFormation`), or a config, if we need to pass a parameters to client constructor, e.g.:
 
 ```javascript
 {
-  "name": "CloudFormation",
+  "client": require('@aws-sdk/client-cloudformation').CloudFormation,
   "params": {
     "region": "us-east-2" // Override 'us-east-1' default
   }
@@ -33,6 +33,7 @@ Invocation params, passed as direct input to AWS SDK method.
 
 ```javascript
 const awsRequest = require('@serverless/test/aws-request');
+const { CloudFormation } = require('@aws-sdk/client-cloudformation');
 
-const result = await awsRequest('CloudFormation', 'describeStacks', { StackName: stackName });
+const result = await awsRequest(CloudFormation, 'describeStacks', { StackName: stackName });
 ```

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ncjsm": "^4.3.0",
     "p-limit": "^3.1.0",
     "process-utils": "^4.0.0",
-    "sinon": "^12.0.1",
+    "sinon": "^13.0.1",
     "timers-ext": "^0.1.7",
     "type": "^2.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "github-release-from-cc-changelog": "^2.2.0",
     "glob-exec": "^0.1.1",
     "husky": "^4.3.8",
-    "lint-staged": "^10.5.4",
+    "lint-staged": "^12.3.3",
     "mocha": "^8.4.0",
     "prettier": "^2.5.1",
     "standard-version": "^9.3.2"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",
     "@serverless/eslint-config": "^4.0.0",
-    "eslint": "^7.32.0",
+    "eslint": "^8.8.0",
     "eslint-plugin-import": "^2.25.4",
     "git-list-updated": "^1.2.1",
     "github-release-from-cc-changelog": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "child-process-ext": "^2.1.1",
     "cli-progress-footer": "^2.3.0",
     "essentials": "^1.2.0",
-    "fs-extra": "^9.1.0",
+    "fs-extra": "^10.0.0",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "log": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "type": "^2.5.0"
   },
   "devDependencies": {
-    "@commitlint/cli": "^12.1.4",
+    "@commitlint/cli": "^16.1.0",
     "@serverless/eslint-config": "^4.0.0",
     "eslint": "^7.32.0",
     "eslint-plugin-import": "^2.25.4",

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
     "glob-exec": "^0.1.1",
     "husky": "^4.3.8",
     "lint-staged": "^12.3.3",
-    "mocha": "^8.4.0",
+    "mocha": "^9.2.0",
     "prettier": "^2.5.1",
     "standard-version": "^9.3.2"
   },
   "peerDependencies": {
-    "mocha": "8"
+    "mocha": "9"
   },
   "eslintConfig": {
     "extends": "@serverless/eslint-config/node",


### PR DESCRIPTION
To open door for upgrading to AWS SDK v3, I needed to introduce a breaking change in `awsRequest` util. Therefore this will trigger v10 release.

I've tested new `awsRequest` with `serverless` where it's used in integration tests. It can be used against both `aws-sdk` v2 and v3. 

In context of v9 I've also forgot to upgrade mocha to v9, here it's also applied as a breaking change