### PR TITLE
fix: Add `TEMP` to `resolve-env` whitelist

### DIFF
--- a/resolve-env.js
+++ b/resolve-env.js
@@ -13,6 +13,8 @@ module.exports = (options = {}) => {
       'PATH',
       'SERVERLESS_BINARY_PATH',
       'SLS_SCHEMA_CACHE_BASE_DIR',
+      'TEMP',
+      'TMP',
       'TMPDIR',
       'USERPROFILE',
     ].concat(options.whitelist || []),


### PR DESCRIPTION
Reported internally, Github Actions Windows Runner specifies temporary directory returned by `os.tmpdir` in `TEMP`.