### PR TITLE
Mocha Isolated: Fix resolution of Mocha binary

### DIFF
--- a/bin/mocha-isolated.js
+++ b/bin/mocha-isolated.js
@@ -120,7 +120,7 @@ const run = (path) => {
   env.FORCE_COLOR = '1';
   const mochaArgs = [];
   if (argv.require) mochaArgs.push('--require', argv.require);
-  const testPromise = spawn('node', ['node_modules/.bin/_mocha', ...mochaArgs, path], {
+  const testPromise = spawn('node', [require.resolve('mocha/bin/_mocha'), ...mochaArgs, path], {
     stdio: isMultiProcessRun ? null : 'inherit',
     env,
   });


### PR DESCRIPTION
Path to Mocha binary is hardcoded with assumption that Mocha is always installed in current working directory `node_modules.

It may not be the case with multi package repository, where top-level `node_modules` may host `mocha`.

This patch ensures, Mocha is resolved properly in such scenarios