### PR TITLE
AWS Request: Fix handling of AWS SDK v3 responses

### DIFF
--- a/aws-request.js
+++ b/aws-request.js
@@ -28,7 +28,7 @@ const resolveClientData = (clientOrClientConfig) => {
 let lastAwsRequestId = 0;
 module.exports = function awsRequest(clientOrClientConfig, method, ...args) {
   const requestId = ++lastAwsRequestId;
-  awsLog.debug('[%d] %o %s %O', requestId, clientOrClientConfig, method, args);
+  awsLog.debug('[%d] %O %s %O', requestId, clientOrClientConfig, method, args);
   const instance = getClientInstance(...resolveClientData(clientOrClientConfig));
   return instance[method](...args)
     .promise()

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -12,6 +12,7 @@ module.exports = {
       [
         '',
         'Async Leaks Detector',
+        'AWS Request',
         'Environment',
         'Fixtures Engine',
         'Inquirer Stub',


### PR DESCRIPTION
SDK v3 returns promises by default, there's no `promise()` method available