### PR TITLE
AWS Request: Ensure to retry on rate limit exceed

### DIFF
--- a/aws-request.js
+++ b/aws-request.js
@@ -40,7 +40,12 @@ module.exports = function awsRequest(clientOrClientConfig, method, ...args) {
     },
     (error) => {
       awsLog.debug('[%d] %O', requestId, error);
-      if (error.statusCode !== 403 && error.retryable) {
+      const shouldRetry = (() => {
+        if (error.statusCode === 403) return false;
+        if (error.retryable) return true;
+        return false;
+      })();
+      if (shouldRetry) {
         awsLog.debug('[%d] retry', requestId);
         return wait(4000 + Math.random() * 3000).then(() =>
           awsRequest(clientOrClientConfig, method, ...args)

--- a/aws-request.js
+++ b/aws-request.js
@@ -43,6 +43,7 @@ module.exports = function awsRequest(clientOrClientConfig, method, ...args) {
       const shouldRetry = (() => {
         if (error.statusCode === 403) return false;
         if (error.retryable) return true;
+        if (error.Reason === 'CallerRateLimitExceeded') return true;
         return false;
       })();
       if (shouldRetry) {


### PR DESCRIPTION
Probably in SDK v3, error objects changed, and we no longer get retries on Rate limit exceeded. It can be observed in CI fail: https://github.com/serverless/runtime/runs/6230326721?check_suite_focus=true

This patch ensures that we recognize Rate Limit errors with AWS SDK v3