### PR TITLE
Add support for mocha 10

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -10,42 +10,21 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  linuxNode14:
-    name: '[Linux] Node.js v14: Unit tests'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+  linuxNode:
+    strategy:
+      matrix:
+        node-version:
+          - 12.x
+          - 14.x
+          - 16.x
+        mocha-version:
+          - ^9
+          - ^10
+        exclude:
+          - node-version: 12.x
+            mocha-version: ^10 # mocha 10 supports node >= 14
 
-      - name: Retrieve ~/.npm from cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.npm
-          key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-v14-${{ runner.os }}-${{ github.ref }}-
-      - name: Retrieve node_modules from cache
-        id: cacheNodeModules
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: node-modules-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
-          restore-keys: node-modules-v14-${{ runner.os }}-${{ github.ref }}-
-
-      - name: Install Node.js and npm
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-
-      - name: Install dependencies
-        if: steps.cacheNodeModules.outputs.cache-hit != 'true'
-        run: |
-          npm update --no-save
-          npm update --save-dev --no-save
-      - name: Unit tests
-        run: npm test
-
-  linuxNode16:
-    name: '[Linux] Node.js 16: Unit tests'
+    name: '[Linux] Node.js v${{matrix.node-version}}: Unit tests'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -58,53 +37,20 @@ jobs:
           path: |
             ~/.npm
             node_modules
-          key: npm-v16-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-v16-${{ runner.os }}-${{ github.ref }}-
+          key: npm-v${{matrix.node-version}}-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
+          restore-keys: npm-v${{matrix.node-version}}-${{ runner.os }}-${{ github.ref }}-
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: ${{matrix.node-version}}
 
       - name: Install dependencies
         if: steps.cacheNpm.outputs.cache-hit != 'true'
         run: |
           npm update --no-save
           npm update --save-dev --no-save
-      - name: Unit tests
-        run: npm test
-
-  linuxNode12:
-    name: '[Linux] Node.js v12: Unit tests'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Retrieve ~/.npm from cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.npm
-          key: npm-v12-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-v12-${{ runner.os }}-${{ github.ref }}-
-      - name: Retrieve node_modules from cache
-        id: cacheNodeModules
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: node-modules-v12-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
-          restore-keys: node-modules-v12-${{ runner.os }}-${{ github.ref }}-
-
-      - name: Install Node.js and npm
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
-
-      - name: Install dependencies
-        if: steps.cacheNodeModules.outputs.cache-hit != 'true'
-        run: |
-          npm update --no-save
-          npm update --save-dev --no-save
+          npm install --no-save mocha@${{ matrix.mocha-version }}
       - name: Unit tests
         run: npm test
 

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -10,21 +10,43 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  linuxNode:
-    strategy:
-      matrix:
-        node-version:
-          - 12.x
-          - 14.x
-          - 16.x
-        mocha-version:
-          - ^9
-          - ^10
-        exclude:
-          - node-version: 12.x
-            mocha-version: ^10 # mocha 10 supports node >= 14
+  linuxNode14:
+    name: '[Linux] Node.js v14: Unit tests'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    name: '[Linux] Node.js v${{matrix.node-version}}: Unit tests'
+      - name: Retrieve ~/.npm from cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
+          restore-keys: npm-v14-${{ runner.os }}-${{ github.ref }}-
+      - name: Retrieve node_modules from cache
+        id: cacheNodeModules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: node-modules-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
+          restore-keys: node-modules-v14-${{ runner.os }}-${{ github.ref }}-
+
+      - name: Install Node.js and npm
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+
+      - name: Install dependencies
+        if: steps.cacheNodeModules.outputs.cache-hit != 'true'
+        run: |
+          npm update --no-save
+          npm update --save-dev --no-save
+          npm install --no-save mocha@10
+      - name: Unit tests
+        run: npm test
+
+  linuxNode16:
+    name: '[Linux] Node.js 16: Unit tests'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -37,20 +59,53 @@ jobs:
           path: |
             ~/.npm
             node_modules
-          key: npm-v${{matrix.node-version}}-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-v${{matrix.node-version}}-${{ runner.os }}-${{ github.ref }}-
+          key: npm-v16-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
+          restore-keys: npm-v16-${{ runner.os }}-${{ github.ref }}-
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.node-version}}
+          node-version: 16.x
 
       - name: Install dependencies
         if: steps.cacheNpm.outputs.cache-hit != 'true'
         run: |
           npm update --no-save
           npm update --save-dev --no-save
-          npm install --no-save mocha@${{ matrix.mocha-version }}
+      - name: Unit tests
+        run: npm test
+
+  linuxNode12:
+    name: '[Linux] Node.js v12: Unit tests'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Retrieve ~/.npm from cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: npm-v12-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
+          restore-keys: npm-v12-${{ runner.os }}-${{ github.ref }}-
+      - name: Retrieve node_modules from cache
+        id: cacheNodeModules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: node-modules-v12-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
+          restore-keys: node-modules-v12-${{ runner.os }}-${{ github.ref }}-
+
+      - name: Install Node.js and npm
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: Install dependencies
+        if: steps.cacheNodeModules.outputs.cache-hit != 'true'
+        run: |
+          npm update --no-save
+          npm update --save-dev --no-save
       - name: Unit tests
         run: npm test
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
       # - `main` build for same commit failed (and we still pushed tag manually)
       # - We've pushed tag manually before `main` build finalized
       - name: Install dependencies
-        if: steps.cacheNpm.outputs.cache-hit != 'true'
+        if: steps.cacheNodeModules.outputs.cache-hit != 'true'
         run: |
           npm update --no-save
           npm update --save-dev --no-save

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           npm update --no-save
           npm update --save-dev --no-save
+          npm install --no-save mocha@10
       - name: Validate Prettier formatting
         run: npm run prettier-check:updated
       - name: Validate ESLint rules

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
     "glob-exec": "^0.1.1",
     "husky": "^4.3.8",
     "lint-staged": "^12.4.1",
-    "mocha": "^10.0.0",
+    "mocha": "^9.2.2",
     "prettier": "^2.6.2",
     "standard-version": "^9.3.2"
   },
   "peerDependencies": {
-    "mocha": "^9 || ^10"
+    "mocha": "9 || 10"
   },
   "peerDependenciesMeta": {
     "mocha": {

--- a/package.json
+++ b/package.json
@@ -42,12 +42,17 @@
     "glob-exec": "^0.1.1",
     "husky": "^4.3.8",
     "lint-staged": "^12.4.1",
-    "mocha": "^9.2.2",
+    "mocha": "^10.0.0",
     "prettier": "^2.6.2",
     "standard-version": "^9.3.2"
   },
   "peerDependencies": {
-    "mocha": "9"
+    "mocha": "^9 || ^10"
+  },
+  "peerDependenciesMeta": {
+    "mocha": {
+      "optional": true
+    }
   },
   "eslintConfig": {
     "extends": "@serverless/eslint-config/node",


### PR DESCRIPTION
Add support for `mocha@10`.
Additionally, it makes the peer dependency on `mocha` optional, because the hooks provided for mocha aren't used in all cases.
I changed `integration.yml` to use a matrix to test both on `mocha@10` and `mocha@9` and their respective node versions too