### PR TITLE
fix(AWS Request): Retry on `Too Many Requests` error

### DIFF
--- a/aws-request.js
+++ b/aws-request.js
@@ -45,6 +45,7 @@ module.exports = function awsRequest(clientOrClientConfig, method, ...args) {
         if (error.retryable) return true;
         if (error.Reason === 'CallerRateLimitExceeded') return true;
         if (error.message.includes('Rate exceeded')) return true;
+        if (error.message.includes('Too Many Requests')) return true;
         return false;
       })();
       if (shouldRetry) {


### PR DESCRIPTION
Follow up to CI fail caused by `Too Many Requests` error